### PR TITLE
[other] Add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ file_descriptor_set.bin
 
 # include test fixtures for vt100
 !crates/turborepo-vt100/tests/data
+
+/.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "typewirets falke";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    ,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        formatter = pkgs.nixpkgs-fmt;
+
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            pkgs.nodejs_22
+          ];
+        };
+      }
+    );
+}

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "turbo": "^2.4.4",
     "typescript": "5.8.2"
   },
-  "packageManager": "pnpm@10.6.4+sha512.da3d715bfd22a9a105e6e8088cfc7826699332ded60c423b14ec613a185f1602206702ff0fe4c438cb15c979081ce4cb02568e364b15174503a63c7a8e2a5f6c"
+  "packageManager": "pnpm@10.7.1+sha512.2d92c86b7928dc8284f53494fb4201f983da65f0fb4f0d40baafa5cf628fa31dae3e5968f12466f17df7e97310e30f343a648baea1b9b350685dafafffdf5808"
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,38 @@
  * at compile time while providing unique identification at runtime.
  *
  * @template _T The type associated with this symbol. It is only used for type check.
+ * 
+ * Note: We cannot use `type TypedSymbol<_T> = symbol` because TypeScript is structurally typed,
+ * meaning type aliases are checked by their structure, not their name. This leads to type erasure
+ * where the generic parameter T is effectively ignored during type checking because all instances
+ * resolve to the same underlying type (symbol).
+ * 
+ * For example:
+ * ```typescript
+ * type TypedSymbol<T> = symbol;
+ * 
+ * // These are considered the same type by TypeScript:
+ * const userSymbol: TypedSymbol<User> = Symbol('user');
+ * const loggerSymbol: TypedSymbol<Logger> = userSymbol; // No error! 😱
+ * ```
+ * 
+ * By using an object wrapper:
+ * ```typescript
+ * type TypedSymbol<T> = { symbol: symbol };
+ * ```
+ * 
+ * We create a "nominal type" that maintains the relationship with T:
+ * ```typescript
+ * const userSymbol: TypedSymbol<User> = { symbol: Symbol('user') };
+ * const loggerSymbol: TypedSymbol<Logger> = userSymbol; // Error! Types are not compatible 👍
+ * ```
+ * 
+ * This is a common pattern in TypeScript known as "branded types" or "phantom types",
+ * where we use the structure of the type to enforce nominal typing behavior.
+ * 
+ * For more information on TypeScript's structural type system, see:
+ * - TypeScript Handbook on Type Compatibility: https://www.typescriptlang.org/docs/handbook/type-compatibility.html
+ * - TypeScript FAQ on Nominal Types: https://github.com/Microsoft/TypeScript/wiki/FAQ#can-i-make-a-type-alias-nominal
  */
 export type TypedSymbol<_T> = {
   /**


### PR DESCRIPTION
Add nix flake's devShell to provide consistent developing environment. This would give me easy to replicate the dev environment for this particular project regardless of system that can be worked on.

The configuration isn't tested through windows, but MacOS and Linux system should work, as long as the system is configured correct to load nix flake, via nix command, or via nix-direnv.

To know more detail about overall setup, check https://rexk.github.io/ where nix configuration and motivations are explained.