### PR TITLE
feat(core): add getAllInstances methods to TypeWireGroup

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -8,7 +8,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": [".direnv/*", ".next/*", ".turbo/*"]
+    "ignore": [".direnv/*", ".next/*", ".turbo/*", "dist/*"]
   },
   "formatter": {
     "enabled": true,

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -122,12 +122,12 @@ While decorators are popular in other DI solutions, we chose not to use them bec
 
 ### Why Separate Creation from Resolution?
 
-TypeWire separates the definition of how to create a dependency (TypeWireDefinition) from the actual resolution (ResolutionContext):
+TypeWire separates the definition of how to create a dependency (TypeWire) from the actual resolution (ResolutionContext):
 
 - Clearer separation of concerns
 - More flexible composition possibilities
 - Better testability as each aspect can be tested independently
-- Easier to adapt to different container implementations 
+- Easier to adapt to different container implementations
 
 ## Addressing Common DI Criticisms
 
@@ -165,4 +165,39 @@ Dependency Injection (DI) often faces criticism for being "over-engineering" or 
 - Clear guidance on when to use DI
 - Ability to start simple and add complexity as needed
 
-The key insight is that DI isn't about adding complexity - it's about managing complexity that already exists in your application. TypeWire provides the tools to handle this complexity without introducing unnecessary overhead. 
+The key insight is that DI isn't about adding complexity - it's about managing complexity that already exists in your application. TypeWire provides the tools to handle this complexity without introducing unnecessary overhead.
+
+## Working with Wires, Not Containers
+
+TypeWire is designed to work with wires rather than containers. This approach has several benefits:
+
+1. **Container Independence**: Wires can be used with any container that implements the `BindingContext` and `ResolutionContext` interfaces.
+2. **Better Organization**: Wires can be grouped together using `TypeWireGroup` and managed as a unit.
+3. **Type Safety**: Wires provide compile-time type safety without runtime overhead.
+4. **Testability**: Wires can be easily tested in isolation or in groups.
+
+For example, instead of working directly with the container:
+
+```typescript
+// ❌ Working with container directly
+const container = new TypeWireContainer();
+for (const wire of wires) {
+  await wire.apply(container);
+}
+const instance = await container.get(wire.type);
+```
+
+We work with wires:
+
+```typescript
+// ✅ Working with wires
+const wireGroup = typeWireGroupOf(wires);
+await wireGroup.apply(container);
+const instance = await wire.getInstance(container);
+```
+
+This approach makes it easier to:
+- Switch between different container implementations
+- Test components in isolation
+- Organize and manage dependencies
+- Maintain type safety

--- a/docs/di-solution-guide.md
+++ b/docs/di-solution-guide.md
@@ -10,7 +10,7 @@ TypeWire is a lightweight, container-agnostic dependency injection library for T
 
 ### 1. True Type Safety Without Runtime Penalty
 
-Most TypeScript DI solutions either sacrifice type safety or require extensive runtime type information. TypeWire achieves compile-time type safety through its `TypedSymbol` approach without needing runtime reflection or decorators, resulting in:
+Most TypeScript DI solutions either sacrifice type safety or require extensive runtime type information. TypeWire achieves compile-time type safety through its `TypeSymbol` approach without needing runtime reflection or decorators, resulting in:
 
 - Zero reflection-based runtime overhead
 - Smaller bundle size

--- a/docs/ecosystem-comparison.md
+++ b/docs/ecosystem-comparison.md
@@ -2,12 +2,21 @@
 
 This document provides an objective comparison between TypeWire and other dependency injection solutions for TypeScript. The goal is to help developers understand the trade-offs and choose the right tool for their specific needs.
 
+## Bundle Size Comparison
+
+| Library     | Minified | Gzipped |
+|-------------|----------|---------|
+| TypeWire    | 4.9KB    | 1.6KB   |
+| InversifyJS | 15KB     | 5KB     |
+| tsyringe    | 6KB      | 2.5KB   |
+| Awilix      | 8KB      | 3KB     |
+
 ## Comparison Table
 
 | Feature | TypeWire | InversifyJS | tsyringe | Angular DI | NestJS |
 |---------|----------|-------------|----------|------------|--------|
-| **Type Safety** | Strong (TypedSymbol) | Strong | Strong | Strong | Strong |
-| **Bundle Size** | Very Small (<2KB) | Medium (~9KB) | Small (~4KB) | Large (part of Angular) | Large (part of NestJS) |
+| **Type Safety** | Strong (TypeSymbol) | Strong | Strong | Strong | Strong |
+| **Bundle Size** | 1.6KB gzipped | 5KB gzipped | 2.5KB gzipped | Large (part of Angular) | Large (part of NestJS) |
 | **Decorator Usage** | None | Heavy | Heavy | Heavy | Heavy |
 | **Container Required** | Optional | Required | Required | Required | Required |
 | **Async Resolution** | Built-in | Requires plugin | No | No | Built-in |

--- a/packages/core/src/__tests__/container.test.ts
+++ b/packages/core/src/__tests__/container.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { TypeWireContainer, typeWireOf, typedSymbolOf } from "../index";
+import { TypeWireContainer, typeWireOf, typeSymbolOf } from "../index";
 
 // Test interfaces and classes
 interface TestService {
@@ -43,7 +43,7 @@ describe("TypeWireContainer", () => {
 
       // Act
       await testServiceWire.apply(container);
-      const service = testServiceWire.getInstance(container);
+      const service = testServiceWire.getInstanceSync(container);
 
       // Assert
       expect(service).toBeInstanceOf(TestServiceImpl);
@@ -52,13 +52,13 @@ describe("TypeWireContainer", () => {
 
     it("should throw when getting an unbound provider", () => {
       // Arrange
-      const symbol = typedSymbolOf<TestService>("notBound");
+      const symbol = typeSymbolOf<TestService>("notBound");
 
       // Act & Assert
-      expect(() => container.get(symbol)).toThrow(
+      expect(() => container.getSync(symbol)).toThrow(
         expect.objectContaining({
-          reason: "BindingNotFound"
-        })
+          reason: "BindingNotFound",
+        }),
       );
     });
 
@@ -72,7 +72,7 @@ describe("TypeWireContainer", () => {
       const dependentServiceWire = typeWireOf<DependentService>({
         token: "dependentService",
         creator: (resolver) => {
-          const testService = resolver.get(testServiceWire.type);
+          const testService = resolver.getSync(testServiceWire.type);
           return new DependentServiceImpl(testService);
         },
       });
@@ -80,7 +80,7 @@ describe("TypeWireContainer", () => {
       // Act
       await testServiceWire.apply(container);
       await dependentServiceWire.apply(container);
-      const service = dependentServiceWire.getInstance(container);
+      const service = dependentServiceWire.getInstanceSync(container);
 
       // Assert
       expect(service).toBeInstanceOf(DependentServiceImpl);
@@ -98,8 +98,8 @@ describe("TypeWireContainer", () => {
 
       // Act
       await testServiceWire.apply(container);
-      const service1 = container.get(testServiceWire.type);
-      const service2 = container.get(testServiceWire.type);
+      const service1 = container.getSync(testServiceWire.type);
+      const service2 = container.getSync(testServiceWire.type);
 
       // Assert
       expect(service1).toBe(service2); // Same instance
@@ -115,8 +115,8 @@ describe("TypeWireContainer", () => {
 
       // Act
       await testServiceWire.apply(container);
-      const service1 = container.get(testServiceWire.type);
-      const service2 = container.get(testServiceWire.type);
+      const service1 = container.getSync(testServiceWire.type);
+      const service2 = container.getSync(testServiceWire.type);
 
       // Assert
       expect(service1).not.toBe(service2); // Different instances
@@ -137,7 +137,7 @@ describe("TypeWireContainer", () => {
 
       // Act
       await asyncServiceWire.apply(container);
-      const service = await container.getAsync(asyncServiceWire.type);
+      const service = await container.get(asyncServiceWire.type);
 
       // Assert
       expect(service).toBeInstanceOf(TestServiceImpl);
@@ -158,10 +158,10 @@ describe("TypeWireContainer", () => {
       await asyncServiceWire.apply(container);
 
       // Assert
-      expect(() => asyncServiceWire.getInstance(container)).toThrow(
+      expect(() => asyncServiceWire.getInstanceSync(container)).toThrow(
         expect.objectContaining({
-          reason: "AsyncOnlyBinding"
-        })
+          reason: "AsyncOnlyBinding",
+        }),
       );
     });
 
@@ -179,8 +179,8 @@ describe("TypeWireContainer", () => {
 
       // Act
       await asyncServiceWire.apply(container);
-      const service1 = await container.getAsync(asyncServiceWire.type);
-      const service2 = await container.getAsync(asyncServiceWire.type);
+      const service1 = await container.get(asyncServiceWire.type);
+      const service2 = await container.get(asyncServiceWire.type);
 
       // Assert
       expect(service1).toBe(service2); // Same instance
@@ -204,10 +204,10 @@ describe("TypeWireContainer", () => {
 
       // Assert
       expect(container.isBound(testServiceWire.type)).toBe(false);
-      expect(() => container.get(testServiceWire.type)).toThrow(
+      expect(() => container.getSync(testServiceWire.type)).toThrow(
         expect.objectContaining({
-          reason: "BindingNotFound"
-        })
+          reason: "BindingNotFound",
+        }),
       );
     });
 
@@ -220,12 +220,12 @@ describe("TypeWireContainer", () => {
 
       // Act - Get instance to cache it
       await testServiceWire.apply(container);
-      const service1 = container.get(testServiceWire.type);
+      const service1 = container.getSync(testServiceWire.type);
 
       // Unbind and rebind
       container.unbind(testServiceWire.type);
       await testServiceWire.apply(container);
-      const service2 = container.get(testServiceWire.type);
+      const service2 = container.getSync(testServiceWire.type);
 
       // Assert
       expect(service1).not.toBe(service2); // Different instances
@@ -242,7 +242,7 @@ describe("TypeWireContainer", () => {
 
       // Act
       await testServiceWire.apply(container);
-      const service = testServiceWire.getInstance(container);
+      const service = testServiceWire.getInstanceSync(container);
 
       // Assert
       expect(service).toBeInstanceOf(TestServiceImpl);
@@ -261,7 +261,7 @@ describe("TypeWireContainer", () => {
 
       // Act
       await asyncServiceWire.apply(container);
-      const service = await asyncServiceWire.getInstanceAsync(container);
+      const service = await asyncServiceWire.getInstance(container);
 
       // Assert
       expect(service).toBeInstanceOf(TestServiceImpl);
@@ -287,13 +287,13 @@ describe("TypeWireContainer", () => {
 
       // Verify behavior
       await singletonWire.apply(container);
-      const singleton1 = container.get(singletonWire.type);
-      const singleton2 = container.get(singletonWire.type);
+      const singleton1 = container.getSync(singletonWire.type);
+      const singleton2 = container.getSync(singletonWire.type);
       expect(singleton1).toBe(singleton2); // Same instance
 
       await transientWire.apply(container);
-      const transient1 = container.get(transientWire.type);
-      const transient2 = container.get(transientWire.type);
+      const transient1 = container.getSync(transientWire.type);
+      const transient2 = container.getSync(transientWire.type);
       expect(transient1).not.toBe(transient2); // Different instances
     });
 
@@ -315,12 +315,12 @@ describe("TypeWireContainer", () => {
 
       // Verify behavior
       await originalWire.apply(container);
-      const original = container.get(originalWire.type);
+      const original = container.getSync(originalWire.type);
       expect(original.getValue()).toBe("original");
 
       container.unbind(originalWire.type);
       await newWire.apply(container);
-      const modified = container.get(newWire.type);
+      const modified = container.getSync(newWire.type);
       expect(modified.getValue()).toBe("modified");
     });
   });

--- a/packages/core/src/__tests__/integration.test.ts
+++ b/packages/core/src/__tests__/integration.test.ts
@@ -59,13 +59,13 @@ describe("TypeWireTS Integration", () => {
     const serviceBProvider = typeWireOf<ServiceB>({
       token: "serviceB",
       creator: (resolver) =>
-        new ServiceBImpl(serviceAProvider.getInstance(resolver)),
+        new ServiceBImpl(serviceAProvider.getInstanceSync(resolver)),
     });
 
     const serviceCProvider = typeWireOf<ServiceC>({
       token: "serviceC",
       creator: (resolver) =>
-        new ServiceCImpl(serviceBProvider.getInstance(resolver)),
+        new ServiceCImpl(serviceBProvider.getInstanceSync(resolver)),
     });
 
     // Act
@@ -73,7 +73,7 @@ describe("TypeWireTS Integration", () => {
     await serviceBProvider.apply(container);
     await serviceCProvider.apply(container);
 
-    const serviceC = serviceCProvider.getInstance(container);
+    const serviceC = serviceCProvider.getInstanceSync(container);
 
     // Assert
     expect(serviceC.getName()).toBe("ServiceC");
@@ -89,7 +89,7 @@ describe("TypeWireTS Integration", () => {
       token: "serviceA",
       creator: (resolver) => {
         // This creates a circular dependency
-        serviceCProvider.getInstance(resolver);
+        serviceCProvider.getInstanceSync(resolver);
         return new ServiceAImpl();
       },
     });
@@ -97,23 +97,23 @@ describe("TypeWireTS Integration", () => {
     const serviceBProvider = typeWireOf<ServiceB>({
       token: "serviceB",
       creator: (resolver) =>
-        new ServiceBImpl(serviceAProvider.getInstance(resolver)),
+        new ServiceBImpl(serviceAProvider.getInstanceSync(resolver)),
     });
 
     const serviceCProvider = typeWireOf<ServiceC>({
       token: "serviceC",
       creator: (resolver) =>
-        new ServiceCImpl(serviceBProvider.getInstance(resolver)),
+        new ServiceCImpl(serviceBProvider.getInstanceSync(resolver)),
     });
 
     // Act & Assert
     await serviceAProvider.apply(container);
     await serviceBProvider.apply(container);
     await serviceCProvider.apply(container);
-    expect(() => serviceCProvider.getInstance(container)).toThrow(
+    expect(() => serviceCProvider.getInstanceSync(container)).toThrow(
       expect.objectContaining({
-        reason: "CircularDependency"
-      })
+        reason: "CircularDependency",
+      }),
     );
   });
 
@@ -132,7 +132,7 @@ describe("TypeWireTS Integration", () => {
     const serviceBProvider = typeWireOf<ServiceB>({
       token: "serviceB",
       creator: async (resolver) => {
-        const serviceA = await resolver.getAsync(serviceAProvider.type);
+        const serviceA = await resolver.get(serviceAProvider.type);
         return new ServiceBImpl(serviceA);
       },
     });
@@ -141,7 +141,7 @@ describe("TypeWireTS Integration", () => {
     await serviceAProvider.apply(container);
     await serviceBProvider.apply(container);
 
-    const serviceB = await serviceBProvider.getInstanceAsync(container);
+    const serviceB = await serviceBProvider.getInstance(container);
 
     // Assert
     expect(serviceB.getName()).toBe("ServiceB");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,29 +4,24 @@
  *
  * @template _T The type associated with this symbol. It is only used for type check.
  *
- * Note: We cannot use `type TypedSymbol<_T> = symbol` because TypeScript is structurally typed,
- * meaning type aliases are checked by their structure, not their name. This leads to type erasure
- * where the generic parameter T is effectively ignored during type checking because all instances
- * resolve to the same underlying type (symbol).
+ * Note: We cannot use `type TypeSymbol<_T> = symbol` because TypeScript is structurally typed,
+ * which means that two symbols with the same structure are considered compatible.
+ * This would allow type mismatches to go undetected.
  *
  * For example:
  * ```typescript
- * type TypedSymbol<T> = symbol;
+ * type TypeSymbol<T> = symbol;
  *
- * // These are considered the same type by TypeScript:
- * const userSymbol: TypedSymbol<User> = Symbol('user');
- * const loggerSymbol: TypedSymbol<Logger> = userSymbol; // No error! 😱
+ * const userSymbol: TypeSymbol<User> = Symbol('user');
+ * const loggerSymbol: TypeSymbol<Logger> = userSymbol; // No error! 😱
  * ```
  *
- * By using an object wrapper:
+ * Instead, we use an object type to ensure type safety:
  * ```typescript
- * type TypedSymbol<T> = { symbol: symbol };
- * ```
+ * type TypeSymbol<T> = { symbol: symbol };
  *
- * We create a "nominal type" that maintains the relationship with T:
- * ```typescript
- * const userSymbol: TypedSymbol<User> = { symbol: Symbol('user') };
- * const loggerSymbol: TypedSymbol<Logger> = userSymbol; // Error! Types are not compatible 👍
+ * const userSymbol: TypeSymbol<User> = { symbol: Symbol('user') };
+ * const loggerSymbol: TypeSymbol<Logger> = userSymbol; // Error! Types are not compatible 👍
  * ```
  *
  * This is a common pattern in TypeScript known as "branded types" or "phantom types",
@@ -36,7 +31,7 @@
  * - TypeScript Handbook on Type Compatibility: https://www.typescriptlang.org/docs/handbook/type-compatibility.html
  * - TypeScript FAQ on Nominal Types: https://github.com/Microsoft/TypeScript/wiki/FAQ#can-i-make-a-type-alias-nominal
  */
-export type TypedSymbol<_T> = {
+export type TypeSymbol<_T> = {
   /**
    * The underlying JavaScript Symbol
    */
@@ -44,19 +39,32 @@ export type TypedSymbol<_T> = {
 };
 
 /**
- * Constant representing the singleton scope for dependency instances.
+ * Type alias for any for prevent
+ * linting errors for a convenience
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Explicitly looking for any type
+type AnyType = any;
+
+/**
+ * A type symbol that can represent any type.
+ * Used when the specific type is not important or unknown.
+ */
+export type AnyTypeSymbol = TypeSymbol<AnyType>;
+
+/**
+ * Constant representing the singleton scope for dependencies.
  * When a dependency is registered with this scope, the same instance
  * will be returned for all resolutions.
  */
 const ScopeSingleton = "singleton";
 
 /**
- * Gets a human-readable description of a typed symbol.
- * @param typedSymbol - The typed symbol to get the description for
- * @returns The symbol's description or "unknown" if no description is available
+ * Gets the description of a type symbol.
+ * @param typeSymbol - The type symbol to get the description for
+ * @returns The description of the symbol, or "unknown" if none exists
  */
-function getDescription(typedSymbol: TypedSymbol<unknown>): string {
-  return typedSymbol.symbol.description ?? "unknown";
+function getDescription(typeSymbol: TypeSymbol<unknown>): string {
+  return typeSymbol.symbol.description ?? "unknown";
 }
 
 /**
@@ -68,21 +76,21 @@ export interface ResolutionContext {
    * Gets an instance of type T synchronously.
    *
    * @template T The type of instance to get
-   * @param typedSymbol The typed symbol identifying the dependency
+   * @param typeSymbol The type symbol identifying the dependency
    * @returns An instance of type T
    * @throws Error if the dependency cannot be resolved synchronously or is not found
    */
-  get<T>(typedSymbol: TypedSymbol<T>): T;
+  getSync<T>(typeSymbol: TypeSymbol<T>): T;
 
   /**
    * Gets an instance of type T asynchronously.
    *
    * @template T The type of instance to get
-   * @param typedSymbol The typed symbol identifying the dependency
+   * @param typeSymbol The type symbol identifying the dependency
    * @returns A promise that resolves to an instance of type T
    * @throws Error if the dependency is not found
    */
-  getAsync<T>(typedSymbol: TypedSymbol<T>): Promise<T>;
+  get<T>(typeSymbol: TypeSymbol<T>): Promise<T>;
 }
 
 /**
@@ -95,25 +103,22 @@ export interface BindingContext {
    *
    * @param typeWire The Typewire to bind
    */
-  // biome-ignore lint/suspicious/noExplicitAny: bind can take any type of wiring definition
-  bind(typeWire: TypeWireDefinition<any>): void;
+  bind(typeWire: AnyTypeWire): void;
 
   /**
    * Removes a binding from the container.
    *
-   * @param typedSymbol The typed symbol identifying the binding to remove
+   * @param typeSymbol The type symbol identifying the binding to remove
    */
-  // biome-ignore lint/suspicious/noExplicitAny: unbind can take any type of typed symbol
-  unbind(typedSymbol: TypedSymbol<any>): Promise<void>;
+  unbind(typeSymbol: AnyTypeSymbol): Promise<void>;
 
   /**
    * Checks if a binding exists in the container.
    *
-   * @param typedSymbol The typed symbol to check
+   * @param typeSymbol The type symbol to check
    * @returns True if the binding exists, false otherwise
    */
-  // biome-ignore lint/suspicious/noExplicitAny: isBound can take any TypeSymbol
-  isBound(typedSymbol: TypedSymbol<any>): boolean;
+  isBound(typeSymbol: AnyTypeSymbol): boolean;
 }
 
 /**
@@ -125,9 +130,28 @@ export interface BindingContext {
  */
 export type Creator<T> = (context: ResolutionContext) => T | Promise<T>;
 
+/**
+ * A function that can decorate or replace a creator function.
+ * Can be either a new creator function or a function that takes the original
+ * creator and returns a new one.
+ */
 export type CreatorDecorator<T> =
   | Creator<T>
   | ((context: ResolutionContext, creator: Creator<T>) => T | Promise<T>);
+
+/**
+ * Interface for types that can be applied to a BindingContext.
+ * This is the common interface shared by TypeWire and TypeWireGroup.
+ */
+export interface Applicable {
+  /**
+   * Registers this type with a dependency binder.
+   *
+   * @param binder The dependency binder to register with
+   * @returns A promise that resolves when registration is complete
+   */
+  apply(binder: BindingContext): void | Promise<void>;
+}
 
 /**
  * Defines a provider for creating and retrieving typed instances.
@@ -136,11 +160,11 @@ export type CreatorDecorator<T> =
  *
  * @template T The type of instance this provider creates
  */
-export interface TypeWireDefinition<T> {
+export interface TypeWire<T> extends Applicable {
   /**
    * The unique typed symbol that identifies this provider.
    */
-  readonly type: TypedSymbol<T>;
+  readonly type: TypeSymbol<T>;
 
   /**
    * The scope that determines instance lifecycle.
@@ -155,21 +179,13 @@ export interface TypeWireDefinition<T> {
   readonly creator: Creator<T>;
 
   /**
-   * Registers this provider with a dependency binder.
-   *
-   * @param binder The dependency binder to register with
-   * @returns A promise that resolves when registration is complete
-   */
-  apply(binder: BindingContext): void | Promise<void>;
-
-  /**
    * Retrieves an instance of type T synchronously.
    *
    * @param resolver The dependency resolver to use
    * @returns An instance of type T
    * @throws Error if the instance cannot be resolved synchronously
    */
-  getInstance(resolver: ResolutionContext): T;
+  getInstanceSync(resolver: ResolutionContext): T;
 
   /**
    * Retrieves an instance of type T asynchronously.
@@ -177,7 +193,7 @@ export interface TypeWireDefinition<T> {
    * @param resolver The dependency resolver to use
    * @returns A promise that resolves to an instance of type T
    */
-  getInstanceAsync(resolver: ResolutionContext): Promise<T>;
+  getInstance(resolver: ResolutionContext): Promise<T>;
 
   /**
    * Creates a new provider with the specified scope.
@@ -186,7 +202,7 @@ export interface TypeWireDefinition<T> {
    * @param scope The scope to use for the new provider
    * @returns A new provider with the updated scope
    */
-  withScope(scope: string): TypeWireDefinition<T>;
+  withScope(scope: string): TypeWire<T>;
 
   /**
    * Creates a new provider with the specified implementation.
@@ -195,15 +211,235 @@ export interface TypeWireDefinition<T> {
    * @param create The creator function for the new provider
    * @returns A new provider with the updated implementation
    */
-  withCreator(create: CreatorDecorator<T>): TypeWireDefinition<T>;
+  withCreator(create: CreatorDecorator<T>): TypeWire<T>;
 }
+
+export type InferWireType<W> = W extends TypeWire<infer T> ? T : never;
+
+/**
+ * A group of TypeWire instances that create instances of type T.
+ * This type allows you to manage multiple wires together and apply them
+ * to a container in a single operation.
+ *
+ * @template T The type of instances created by the wires in this group
+ */
+export interface TypeWireGroup<T> extends Applicable {
+  /**
+   * The array of TypeWire instances in this group.
+   */
+  wires: TypeWire<T>[];
+
+  /**
+   * Retrieves all instances from the group asynchronously.
+   * This method resolves all instances in parallel, making it more efficient than
+   * sequential resolution when dealing with multiple async dependencies.
+   *
+   * This method is particularly useful for pre-loading async resources during application
+   * startup. Once pre-loaded, singleton resources can be accessed synchronously using
+   * getAllInstancesSync for better performance in hot code paths.
+   *
+   * @param resolver - The resolution context used to resolve dependencies
+   * @returns A promise that resolves to an array of all instances in the group
+   * @throws {TypeWireError} If any instance fails to resolve
+   *
+   * @example
+   * ```typescript
+   * // Pre-load all services during startup
+   * const group = typeWireGroupOf([userServiceWire, loggerWire]);
+   * await group.getAllInstances(container);
+   *
+   * // Later, access pre-loaded singletons synchronously
+   * const [userService, logger] = group.getAllInstancesSync(container);
+   *
+   * // Or access individual instances using their wires
+   * const userService = await userServiceWire.getInstance(container);
+   * const logger = loggerWire.getInstanceSync(container);
+   * ```
+   */
+  getAllInstances(resolver: ResolutionContext): Promise<T[]>;
+
+  /**
+   * Retrieves all instances from the group synchronously.
+   * This method is useful when all dependencies are known to be synchronous
+   * or when working in a context where async operations are not allowed.
+   *
+   * Note: This method will throw if any of the instances require async resolution.
+   * For async dependencies, use getAllInstances instead.
+   *
+   * @param resolver - The resolution context used to resolve dependencies
+   * @returns An array of all instances in the group
+   * @throws {TypeWireError} If any instance fails to resolve or requires async resolution
+   *
+   * @example
+   * ```typescript
+   * // For synchronous services
+   * const group = typeWireGroupOf([configWire, loggerWire]);
+   * const [config, logger] = group.getAllInstancesSync(container);
+   *
+   * // Or access individual instances using their wires
+   * const config = configWire.getInstanceSync(container);
+   * const logger = loggerWire.getInstanceSync(container);
+   * ```
+   */
+  getAllInstancesSync(resolver: ResolutionContext): T[];
+}
+
+/**
+ * Standard implementation of the TypeWireGroup interface.
+ * This class provides a concrete implementation that can be used directly
+ * or extended for custom behavior.
+ *
+ * @template T The type of instances created by the wires in this group
+ */
+export class StandardTypeWireGroup<T> implements TypeWireGroup<T> {
+  /**
+   * Creates a new StandardTypeWireGroup with the given wires.
+   *
+   * @param wires The TypeWire instances to include in this group
+   */
+  constructor(readonly wires: TypeWire<T>[]) {}
+
+  async getAllInstances(resolver: ResolutionContext): Promise<T[]> {
+    return await Promise.all(
+      this.wires.map((wire) => wire.getInstance(resolver)),
+    );
+  }
+
+  getAllInstancesSync(resolver: ResolutionContext): T[] {
+    return this.wires.map((wire) => wire.getInstanceSync(resolver));
+  }
+
+  /**
+   * Applies all wires in this group to the given binder.
+   * This is done sequentially to maintain a predictable order.
+   *
+   * @param binder The dependency binder to register with
+   */
+  async apply(binder: BindingContext) {
+    for (const wire of this.wires) {
+      await wire.apply(binder);
+    }
+  }
+}
+
+/**
+ * Creates a group of TypeWire instances.
+ * This is a convenience function that helps with type inference and linter rules.
+ * It allows you to group wires without having to explicitly specify types or
+ * deal with linter warnings about 'any' types.
+ *
+ * @template T The type of instances created by the wires
+ * @param wires The TypeWire instances to group
+ * @returns A TypeWireGroup containing the provided wires
+ *
+ * @example
+ * ```ts
+ * // Define a base type for your components
+ * interface Service {
+ *   start(): Promise<void>;
+ * }
+ *
+ * // Create typed wires for each service
+ * const DatabaseServiceWire = typeWireOf({
+ *   token: 'DatabaseService',
+ *   creator: () => new DatabaseService()
+ * });
+ *
+ * const CacheServiceWire = typeWireOf({
+ *   token: 'CacheService',
+ *   creator: () => new CacheService()
+ * });
+ *
+ * // Create a group of service wires
+ * const serviceWires = typeWireGroupOf([
+ *   DatabaseServiceWire,
+ *   CacheServiceWire
+ * ]);
+ *
+ * // Apply all wires in the group
+ * await serviceWires.apply(container);
+ * ```
+ */
+export function typeWireGroupOf<T>(wires: TypeWire<T>[]): TypeWireGroup<T>;
+export function typeWireGroupOf(
+  wires: TypeWire<AnyType>[],
+): TypeWireGroup<AnyType>;
+export function typeWireGroupOf(
+  wires: TypeWire<AnyType>[],
+): TypeWireGroup<AnyType> {
+  return new StandardTypeWireGroup(wires);
+}
+
+/**
+ * Combines multiple groups of TypeWire instances into a single group.
+ * This is a convenience function that helps with type inference and linter rules,
+ * similar to typeWireGroupOf but for combining multiple groups.
+ *
+ * @template T The type of instances created by the wires
+ * @param wireGroups The groups of TypeWire instances to combine
+ * @returns A single TypeWireGroup containing all wires
+ *
+ * @example
+ * ```typescript
+ * // Define your wire groups in separate files
+ * // core.wires.ts
+ * export const CoreWires = typeWireGroupOf([
+ *   UserServiceWire,
+ *   AuthServiceWire
+ * ]);
+ *
+ * // feature.wires.ts
+ * export const FeatureWires = typeWireGroupOf([
+ *   FeatureServiceWire,
+ *   FeatureControllerWire
+ * ]);
+ *
+ * // Combine them in your app setup
+ * const allWires = combineWireGroups([
+ *   CoreWires,
+ *   FeatureWires
+ * ]);
+ *
+ * // Apply all wires
+ * await allWires.apply(container);
+ * ```
+ */
+export function combineWireGroups<T>(
+  wireGroups: TypeWireGroup<T>[],
+): TypeWireGroup<T>;
+export function combineWireGroups(
+  wireGroups: AnyTypeWireGroup[],
+): AnyTypeWireGroup;
+export function combineWireGroups(
+  wireGroups: AnyTypeWireGroup[],
+): AnyTypeWireGroup {
+  const wires = wireGroups.flatMap((group) => group.wires);
+  return new StandardTypeWireGroup(wires);
+}
+
+/**
+ * A TypeWire that can create any type of instance.
+ * This type is used internally to help with type inference and linter rules.
+ * It allows TypeWire methods to work with any wire type without requiring
+ * explicit type annotations or dealing with linter warnings.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Explicitly looking for any type
+export type AnyTypeWire = TypeWire<any>;
+
+/**
+ * An array of TypeWire instances that can create any type of instance.
+ * This type is used internally to help with type inference and linter rules,
+ * similar to AnyTypeWire but for arrays of wires.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Explicitly looking for any type
+export type AnyTypeWireGroup = TypeWireGroup<any>;
 
 /**
  * Standard implementation of the ProviderDefinition interface.
  *
  * @template T The type of instance this provider creates
  */
-export class StandardTypeWire<T> implements TypeWireDefinition<T> {
+export class StandardTypeWire<T> implements TypeWire<T> {
   /**
    * Creates a new StandardProvider.
    *
@@ -212,7 +448,7 @@ export class StandardTypeWire<T> implements TypeWireDefinition<T> {
    * @param scope Optional scope that determines instance lifecycle
    */
   constructor(
-    readonly type: TypedSymbol<T>,
+    readonly type: TypeSymbol<T>,
     readonly creator: Creator<T>,
     readonly scope?: string,
   ) {}
@@ -238,8 +474,8 @@ export class StandardTypeWire<T> implements TypeWireDefinition<T> {
    * @returns An instance of type T
    * @throws Error if the instance cannot be resolved synchronously
    */
-  getInstance(resolver: ResolutionContext): T {
-    return resolver.get(this.type);
+  getInstanceSync(resolver: ResolutionContext): T {
+    return resolver.getSync(this.type);
   }
 
   /**
@@ -248,8 +484,8 @@ export class StandardTypeWire<T> implements TypeWireDefinition<T> {
    * @param resolver The dependency resolver to use
    * @returns A promise that resolves to an instance of type T
    */
-  getInstanceAsync(resolver: ResolutionContext): Promise<T> {
-    return resolver.getAsync(this.type);
+  getInstance(resolver: ResolutionContext): Promise<T> {
+    return resolver.get(this.type);
   }
 
   /**
@@ -259,7 +495,7 @@ export class StandardTypeWire<T> implements TypeWireDefinition<T> {
    * @param scope The scope to use for the new provider
    * @returns A new provider with the updated scope
    */
-  withScope(scope: string): TypeWireDefinition<T> {
+  withScope(scope: string): TypeWire<T> {
     return new StandardTypeWire(this.type, this.creator, scope);
   }
 
@@ -270,7 +506,7 @@ export class StandardTypeWire<T> implements TypeWireDefinition<T> {
    * @param create The creator function for the new provider
    * @returns A new provider with the updated implementation
    */
-  withCreator(create: CreatorDecorator<T>): TypeWireDefinition<T> {
+  withCreator(create: CreatorDecorator<T>): TypeWire<T> {
     return new StandardTypeWire(
       this.type,
       (ctx) => create(ctx, this.creator),
@@ -280,8 +516,8 @@ export class StandardTypeWire<T> implements TypeWireDefinition<T> {
 }
 
 /**
- * Helper function to check if a value is a Promise.
- * @template T The type of the promise value
+ * Checks if a value is a Promise.
+ * @template T The type of the promise's resolved value
  * @param value The value to check
  * @returns True if the value is a Promise, false otherwise
  */
@@ -290,12 +526,19 @@ function isPromise<T>(value: unknown): value is Promise<T> {
 }
 
 /**
- * Creates a typed symbol for the specified token.
+ * Creates a TypeSymbol for the specified token.
+ *
+ * If possible use typeWireOf, rather than explicitly creating a symbol
+ * yourself.
+ *
+ * A TypeWire instance exposes a TypeSymbol instance that can be
+ * re-used by others.
+ *
  * @template T The type to associate with the symbol
  * @param token A string identifier for debugging purposes
  * @returns A typed symbol for type T
  */
-export function typedSymbolOf<T>(token: string): TypedSymbol<T> {
+export function typeSymbolOf<T>(token: string): TypeSymbol<T> {
   return { symbol: Symbol(token) };
 }
 
@@ -305,9 +548,9 @@ export function typedSymbolOf<T>(token: string): TypedSymbol<T> {
  */
 export interface TypeWireOpts<T> {
   /**
-   * A string identifier for debugging purposes.
+   * A string or symbol identifier for debugging purposes.
    */
-  token: string;
+  token: string | symbol;
 
   /**
    * The creator function that creates instances of type T.
@@ -328,9 +571,10 @@ export interface TypeWireOpts<T> {
  * @param opts Options for creating the provider
  * @returns A provider definition for type T
  */
-export function typeWireOf<T>(opts: TypeWireOpts<T>): TypeWireDefinition<T> {
+export function typeWireOf<T>(opts: TypeWireOpts<T>): TypeWire<T> {
   const { token, creator, scope } = opts;
-  const typedSymbol = typedSymbolOf<T>(token);
+  const typedSymbol =
+    typeof token === "string" ? typeSymbolOf<T>(token) : { symbol: token };
   return new StandardTypeWire(typedSymbol, creator, scope);
 }
 
@@ -366,23 +610,23 @@ export interface ResolutionMonitor {
   /**
    * Monitors a synchronous dependency resolution.
    * @template T The type of the resolution result
-   * @param typedSymbol The typed symbol being resolved
+   * @param typeSymbol The typed symbol being resolved
    * @param action The synchronous resolution function to execute
    * @returns The result of the resolution function
    * @throws {TypeWireError | Error} If resolution fails
    */
-  monitor<T>(typedSymbol: TypedSymbol<T>, action: SyncAction<T>): T;
+  monitor<T>(typeSymbol: TypeSymbol<T>, action: SyncAction<T>): T;
 
   /**
    * Monitors an asynchronous dependency resolution.
    * @template T The type of the resolution result
-   * @param typedSymbol The typed symbol being resolved
+   * @param typeSymbol The typed symbol being resolved
    * @param action The asynchronous resolution function to execute
    * @returns A promise that resolves to the result of the resolution function
    * @throws {TypeWireError | Error} If resolution fails
    */
   monitorAsync<T>(
-    typedSymbol: TypedSymbol<T>,
+    typeSymbol: TypeSymbol<T>,
     action: AsyncAction<T>,
   ): Promise<T>;
 }
@@ -400,7 +644,7 @@ export class CircularDependencyMonitor implements ResolutionMonitor {
   /**
    * The current resolution path.
    */
-  private readonly resolutionStack: TypedSymbol<unknown>[] = [];
+  private readonly resolutionStack: TypeSymbol<unknown>[] = [];
 
   /**
    * Optional limit on how many path items to display in error messages.
@@ -418,88 +662,81 @@ export class CircularDependencyMonitor implements ResolutionMonitor {
   }
 
   /**
-   * Adds a typed symbol to the resolution stack.
-   * @param typedSymbol The typed symbol to add
+   * Adds a type symbol to the resolution set and stack.
+   * @param typeSymbol The type symbol to add
    */
-  private add(typedSymbol: TypedSymbol<unknown>) {
-    this.resolutionSet.add(typedSymbol.symbol);
-    this.resolutionStack.push(typedSymbol);
+  private add(typeSymbol: TypeSymbol<unknown>) {
+    this.resolutionSet.add(typeSymbol.symbol);
+    this.resolutionStack.push(typeSymbol);
   }
 
   /**
-   * Removes a typed symbol from the resolution stack.
-   * @param typedSymbol The typed symbol to remove
+   * Removes a type symbol from the resolution set and stack.
+   * @param typeSymbol The type symbol to remove
    */
-  private remove(typedSymbol: TypedSymbol<unknown>) {
-    this.resolutionSet.delete(typedSymbol.symbol);
+  private remove(typeSymbol: TypeSymbol<unknown>) {
+    this.resolutionSet.delete(typeSymbol.symbol);
     this.resolutionStack.pop();
   }
 
   /**
-   * Tracks a dependency resolution, detecting circular dependencies.
-   * @template T The type of the resolution result
-   * @param typedSymbol The typed symbol being resolved
-   * @param action The resolution function to execute
-   * @returns The result of the resolution function
-   * @throws {TypeWireError | Error} If a circular dependency is detected or action throws
+   * Monitors the resolution of a type symbol to detect circular dependencies.
+   * @template T The type being resolved
+   * @param typeSymbol The type symbol being resolved
+   * @param action The action to perform
+   * @returns The result of the action
+   * @throws Error if a circular dependency is detected
    */
-  monitor<T>(typedSymbol: TypedSymbol<T>, action: SyncAction<T>): T {
+  monitor<T>(typeSymbol: TypeSymbol<T>, action: SyncAction<T>): T {
+    if (this.resolutionSet.has(typeSymbol.symbol)) {
+      throw TypeWireError.circularDependency();
+    }
+
+    this.add(typeSymbol);
     try {
-      // Check for circular dependency
-      if (this.resolutionSet.has(typedSymbol.symbol)) {
-        throw TypeWireError.circularDependency();
-      }
-
-      // Add to resolution stack
-      this.add(typedSymbol);
-
-      // Execute the resolution action
       return action();
-    } catch (err: unknown) {
+    } catch (err) {
       if (err instanceof TypeWireError && !err.message) {
         err.message = getErrorMessage({
-          type: typedSymbol,
+          type: typeSymbol,
           reason: err.reason,
           paths: [...this.resolutionStack],
           numberOfPathsToPrint: this.numberOfPathsToPrint,
         });
-        throw err;
       }
-
       throw err;
     } finally {
-      // Remove from resolution stack when done
-      this.remove(typedSymbol);
+      this.remove(typeSymbol);
     }
   }
 
   /**
    * Tracks an asynchronous dependency resolution, detecting circular dependencies.
    * @template T The type of the resolution result
-   * @param typedSymbol The typed symbol being resolved
+   * @param typeSymbol The typed symbol being resolved
    * @param action The asynchronous resolution function to execute
    * @returns A promise that resolves to the result of the resolution function
    * @throws {TypeWireError | Error} If a circular dependency is detected or action throws
    */
   async monitorAsync<T>(
-    typedSymbol: TypedSymbol<T>,
+    typeSymbol: TypeSymbol<T>,
     action: AsyncAction<T>,
   ): Promise<T> {
     try {
       // Check for circular dependency
-      if (this.resolutionSet.has(typedSymbol.symbol)) {
+      if (this.resolutionSet.has(typeSymbol.symbol)) {
         throw TypeWireError.circularDependency();
       }
 
       // Add to resolution stack
-      this.add(typedSymbol);
+      this.add(typeSymbol);
 
       // Execute the resolution action
       return await action();
     } catch (err: unknown) {
       if (err instanceof TypeWireError && !err.message) {
         err.message = getErrorMessage({
-          type: typedSymbol,
+          type: typeSymbol,
           reason: err.reason,
           paths: [...this.resolutionStack],
           numberOfPathsToPrint: this.numberOfPathsToPrint,
@@ -509,7 +746,7 @@ export class CircularDependencyMonitor implements ResolutionMonitor {
       throw err;
     } finally {
       // Remove from resolution stack when done
-      this.remove(typedSymbol);
+      this.remove(typeSymbol);
     }
   }
 
@@ -523,7 +760,7 @@ export class CircularDependencyMonitor implements ResolutionMonitor {
 }
 
 /**
- * Represents the possible reasons for a TypeWire error.
+ * The possible reasons for a TypeWire error.
  * Can be one of the predefined reasons or a custom string.
  */
 export type ErrorReason =
@@ -606,27 +843,27 @@ export class TypeWireError extends Error {
  */
 export interface TypeWireErrorOpt {
   /** The type symbol that failed to resolve */
-  type: TypedSymbol<unknown>;
+  type: TypeSymbol<unknown>;
 
   /** The reason for the error */
   reason: ErrorReason;
 
   /** The resolution path that led to the error */
-  paths: TypedSymbol<unknown>[];
+  paths: TypeSymbol<unknown>[];
 
   /** Optional limit on how many path items to display in the error message */
   numberOfPathsToPrint?: number;
 }
 
 /**
- * Gets a human-readable instruction for resolving the error based on its reason.
- * @param opts - The error options containing the reason and context
+ * Gets a human-readable instruction for resolving a TypeWire error.
+ * @param opts The error options containing the reason and context
  * @returns A string containing guidance on how to resolve the error
  */
 function getInstruction(opts: TypeWireErrorOpt): string {
   switch (opts.reason) {
     case ReasonAsyncOnlyBinding:
-      return "Use `getInstanceAsync` to resolve this dependency asynchronously.";
+      return "Use `getInstance` to resolve this dependency asynchronously.";
     case ReasonBindingNotFound:
       return "Ensure the dependency is registered in the container before attempting resolution.";
     case ReasonCircularDependency:
@@ -638,13 +875,12 @@ function getInstruction(opts: TypeWireErrorOpt): string {
 
 /**
  * Formats the dependency resolution path for error messages.
- * Handles truncation when the path exceeds the specified length limit.
- * @param paths - The array of type symbols in the resolution path
- * @param numberOfPathsToPrint - Optional limit on how many path items to display
+ * @param paths The array of type symbols in the resolution path
+ * @param numberOfPathsToPrint Optional limit on how many path items to display
  * @returns An object containing the formatted path and any truncation prefix
  */
 function formatDependencyPath(
-  paths: TypedSymbol<unknown>[],
+  paths: TypeSymbol<unknown>[],
   numberOfPathsToPrint?: number,
 ): { prefix: string; formattedPath: string } {
   const connector = " -> ";
@@ -669,8 +905,7 @@ function formatDependencyPath(
 
 /**
  * Formats a complete error message with all components.
- * Includes the error header, reason, resolution instruction, and the resolution path.
- * @param opts - The error options containing all necessary context
+ * @param opts The error options containing all necessary context
  * @returns A formatted error message string
  */
 function getErrorMessage(opts: TypeWireErrorOpt): string {
@@ -699,7 +934,7 @@ export class TypeWireContainer implements ResolutionContext, BindingContext {
   /**
    * Map of symbols to their provider definitions.
    */
-  private readonly bindings: Map<symbol, TypeWireDefinition<unknown>>;
+  private readonly bindings: Map<symbol, TypeWire<unknown>>;
 
   /**
    * Map of symbols to their singleton instances.
@@ -729,70 +964,67 @@ export class TypeWireContainer implements ResolutionContext, BindingContext {
    * Binds a provider to the container.
    * @param provider The provider to bind
    */
-  // biome-ignore lint/suspicious/noExplicitAny: bind can take any type
-  bind(provider: TypeWireDefinition<any>): void {
+  bind(provider: AnyTypeWire): void {
     this.bindings.set(provider.type.symbol, provider);
   }
 
   /**
    * Checks if a binding exists in the container.
-   * @param typedSymbol The typed symbol to check
+   * @param typeSymbol The type symbol to check
    * @returns True if the binding exists, false otherwise
    */
-  // biome-ignore lint/suspicious/noExplicitAny: isBound can take any type
-  isBound(typedSymbol: TypedSymbol<any>): boolean {
-    return this.bindings.has(typedSymbol.symbol);
+  isBound(typeSymbol: AnyTypeSymbol): boolean {
+    return this.bindings.has(typeSymbol.symbol);
   }
 
   /**
    * Removes a binding from the container.
    * Also removes any singleton instances of the binding.
-   * @param typedSymbol The typed symbol identifying the binding to remove
+   * @param typeSymbol The type symbol identifying the binding to remove
    */
-  // biome-ignore lint/suspicious/noExplicitAny: unbind can take any type
-  async unbind(typedSymbol: TypedSymbol<any>): Promise<void> {
-    this.bindings.delete(typedSymbol.symbol);
-    this.singletons.delete(typedSymbol.symbol);
+  async unbind(typeSymbol: AnyTypeSymbol): Promise<void> {
+    this.bindings.delete(typeSymbol.symbol);
+    this.singletons.delete(typeSymbol.symbol);
   }
 
   /**
-   * Gets the provider definition for a typed symbol.
+   * Gets the provider definition for a type symbol.
    * @template T The type of instance the provider creates
-   * @param typedSymbol The typed symbol to get the provider for
+   * @param typeSymbol The type symbol to get the provider for
    * @returns The provider definition
    * @throws Error if no provider is found for the symbol
    */
-  private getBinding<T>(typedSymbol: TypedSymbol<T>): TypeWireDefinition<T> {
-    const binding = this.bindings.get(typedSymbol.symbol);
+  private getBinding<T>(typeSymbol: TypeSymbol<T>): TypeWire<T> {
+    const binding = this.bindings.get(typeSymbol.symbol);
     if (!binding) {
       throw TypeWireError.bindingNotFound();
     }
 
-    return binding as TypeWireDefinition<T>;
+    return binding as TypeWire<T>;
   }
 
   /**
    * Gets an instance of type T asynchronously.
    * Supports both synchronous and asynchronous creators.
    * @template T The type of instance to get
-   * @param typedSymbol The typed symbol identifying the dependency
+   * @param typeSymbol The type symbol identifying the dependency
    * @returns A promise that resolves to an instance of type T
    * @throws Error if the dependency is not found or if a circular dependency is detected
    */
-  async getAsync<T>(typedSymbol: TypedSymbol<T>): Promise<T> {
-    return this.resolutionMonitor.monitorAsync(typedSymbol, async () => {
-      const binding = this.getBinding(typedSymbol);
+  async get<T>(typeSymbol: TypeSymbol<T>): Promise<T> {
+    return this.resolutionMonitor.monitorAsync(typeSymbol, async () => {
+      const binding = this.getBinding(typeSymbol);
       const creator = binding.creator;
       const scope = binding.scope ?? ScopeSingleton;
 
       if (scope === ScopeSingleton) {
-        const singleton = this.singletons.get(typedSymbol.symbol);
+        const singleton = this.singletons.get(typeSymbol.symbol);
         if (singleton) {
           return singleton as T;
         }
 
         const result = await binding.creator(this);
-        this.singletons.set(typedSymbol.symbol, result);
+        this.singletons.set(typeSymbol.symbol, result);
         return result as T;
       }
 
@@ -807,7 +1039,7 @@ export class TypeWireContainer implements ResolutionContext, BindingContext {
   async getAllAsync(): Promise<Map<symbol, unknown>> {
     const result = new Map<symbol, unknown>();
     for (const binding of this.bindings.values()) {
-      result.set(binding.type.symbol, await binding.getInstanceAsync(this));
+      result.set(binding.type.symbol, await binding.getInstance(this));
     }
 
     return result;
@@ -817,19 +1049,19 @@ export class TypeWireContainer implements ResolutionContext, BindingContext {
    * Gets an instance of type T synchronously.
    * Only supports synchronous creators.
    * @template T The type of instance to get
-   * @param typedSymbol The typed symbol identifying the dependency
+   * @param typeSymbol The type symbol identifying the dependency
    * @returns An instance of type T
    * @throws Error if the dependency is not found, if the creator is asynchronous,
    *         or if a circular dependency is detected
    */
-  get<T>(typedSymbol: TypedSymbol<T>): T {
-    return this.resolutionMonitor.monitor(typedSymbol, () => {
-      const binding = this.getBinding(typedSymbol);
+  getSync<T>(typeSymbol: TypeSymbol<T>): T {
+    return this.resolutionMonitor.monitor(typeSymbol, () => {
+      const binding = this.getBinding(typeSymbol);
       const creator = binding.creator;
       const scope = binding.scope ?? ScopeSingleton;
 
       if (scope === ScopeSingleton) {
-        const singleton = this.singletons.get(typedSymbol.symbol);
+        const singleton = this.singletons.get(typeSymbol.symbol);
         if (singleton) {
           return singleton as T;
         }
@@ -839,7 +1071,7 @@ export class TypeWireContainer implements ResolutionContext, BindingContext {
           throw TypeWireError.asyncBindingOnly();
         }
 
-        this.singletons.set(typedSymbol.symbol, result);
+        this.singletons.set(typeSymbol.symbol, result);
         return result as T;
       }
 

--- a/packages/inversify/src/index.ts
+++ b/packages/inversify/src/index.ts
@@ -5,8 +5,9 @@ import type {
   BindingScope,
 } from "inversify";
 import type {
-  TypedSymbol,
-  TypeWireDefinition,
+  TypeSymbol,
+  AnyTypeSymbol,
+  AnyTypeWire,
   ResolutionContext as TypeWireResolutionContext,
   BindingContext,
 } from "@typewirets/core";
@@ -30,11 +31,11 @@ export function adaptToResolutionContext(
   container: Container | InnversifyResolutionContext,
 ): TypeWireResolutionContext {
   return {
-    get<T>(typedSymbol: TypedSymbol<T>): T {
-      return container.get(typedSymbol.symbol);
+    getSync<T>(typeSymbol: TypeSymbol<T>): T {
+      return container.get(typeSymbol.symbol);
     },
-    getAsync<T>(typedSymbol: TypedSymbol<T>): Promise<T> {
-      return container.getAsync(typedSymbol.symbol);
+    get<T>(typeSymbol: TypeSymbol<T>): Promise<T> {
+      return container.getAsync(typeSymbol.symbol);
     },
   } satisfies TypeWireResolutionContext;
 }
@@ -43,8 +44,7 @@ export function adaptToBindingContext(
   container: Container | ContainerModuleLoadOptions,
 ): BindingContext {
   return {
-    // biome-ignore lint/suspicious/noExplicitAny: bind can take any type
-    bind(binding: TypeWireDefinition<any>) {
+    bind(binding: AnyTypeWire) {
       const bound = container
         .bind(binding.type.symbol)
         .toDynamicValue((ctx) => {
@@ -67,14 +67,12 @@ export function adaptToBindingContext(
       }
     },
 
-    // biome-ignore lint/suspicious/noExplicitAny: unbind can take any type
-    async unbind(typedSymbol: TypedSymbol<any>): Promise<void> {
-      await container.unbind(typedSymbol.symbol);
+    async unbind(typeSymbol: AnyTypeSymbol): Promise<void> {
+      await container.unbind(typeSymbol.symbol);
     },
 
-    // biome-ignore lint/suspicious/noExplicitAny: isBound can take any TypeSymbol
-    isBound(typedSymbol: TypedSymbol<any>): boolean {
-      return container.isBound(typedSymbol.symbol);
+    isBound(typeSymbol: AnyTypeSymbol): boolean {
+      return container.isBound(typeSymbol.symbol);
     },
   } satisfies BindingContext;
 }
@@ -94,24 +92,24 @@ export class InversifyAdapter
     this.bindingContext = adaptToBindingContext(container);
   }
 
-  get<T>(typedSymbol: TypedSymbol<T>): T {
-    return this.resolutionContext.get(typedSymbol);
+  getSync<T>(typeSymbol: AnyTypeSymbol): T {
+    return this.resolutionContext.getSync(typeSymbol);
   }
 
-  getAsync<T>(typedSymbol: TypedSymbol<T>): Promise<T> {
-    return this.resolutionContext.getAsync(typedSymbol);
+  get<T>(typeSymbol: TypeSymbol<T>): Promise<T> {
+    return this.resolutionContext.get(typeSymbol);
   }
 
-  bind(typeWire: TypeWireDefinition<unknown>): void | Promise<void> {
+  bind(typeWire: AnyTypeWire): void | Promise<void> {
     return this.bindingContext.bind(typeWire);
   }
 
-  async unbind(typedSymbol: TypedSymbol<unknown>): Promise<void> {
-    await this.bindingContext.unbind(typedSymbol);
+  async unbind(typeSymbol: AnyTypeSymbol): Promise<void> {
+    await this.bindingContext.unbind(typeSymbol);
   }
 
-  isBound(typedSymbol: TypedSymbol<unknown>): boolean {
-    return this.bindingContext.isBound(typedSymbol);
+  isBound(typeSymbol: AnyTypeSymbol): boolean {
+    return this.bindingContext.isBound(typeSymbol);
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,52 @@ importers:
 
   packages/typescript-config: {}
 
+  recipes/express-example:
+    dependencies:
+      '@typewirets/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
+      pg:
+        specifier: ^8.14.1
+        version: 8.14.1
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.1
+        version: 5.0.1
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.13.10
+      '@types/pg':
+        specifier: ^8.11.11
+        version: 8.11.11
+      '@typewirets/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      supertest:
+        specifier: ^7.1.0
+        version: 7.1.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.13.10)(typescript@5.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^3.0.8
+        version: 3.0.8(@types/node@22.13.10)
+
 packages:
 
   '@biomejs/biome@1.9.4':
@@ -121,6 +167,10 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@esbuild/aix-ppc64@0.25.1':
     resolution: {integrity: sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==}
@@ -295,8 +345,15 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@rollup/rollup-android-arm-eabi@4.35.0':
     resolution: {integrity: sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ==}
@@ -393,11 +450,56 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/body-parser@1.19.5':
+    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/express-serve-static-core@5.0.6':
+    resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
+
+  '@types/express@5.0.1':
+    resolution: {integrity: sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==}
+
+  '@types/http-errors@2.0.4':
+    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
+
+  '@types/pg@8.11.11':
+    resolution: {integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==}
+
+  '@types/qs@6.9.18':
+    resolution: {integrity: sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@0.17.4':
+    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+
+  '@types/serve-static@1.15.7':
+    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
 
   '@vitest/expect@3.0.8':
     resolution: {integrity: sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==}
@@ -428,6 +530,19 @@ packages:
   '@vitest/utils@3.0.8':
     resolution: {integrity: sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.14.1:
+    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -444,19 +559,44 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
@@ -472,6 +612,35 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -490,8 +659,30 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -499,43 +690,145 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.1:
     resolution: {integrity: sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==}
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   expect-type@1.2.0:
     resolution: {integrity: sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==}
     engines: {node: '>=12.0.0'}
 
+  express@5.1.0:
+    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  finalhandler@2.1.0:
+    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
+    engines: {node: '>= 0.8'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+
+  formidable@3.5.2:
+    resolution: {integrity: sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   glob@11.0.1:
     resolution: {integrity: sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hexoid@2.0.0:
+    resolution: {integrity: sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==}
+    engines: {node: '>=8'}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inversify@7.1.0:
     resolution: {integrity: sha512-f8SlUTgecMZGr/rsFK36PD84/mH0+sp0/P/TuiGo3CcJywmF5kgoXeE2RW5IjaIt1SlqS5c5V9RuQc1+B8mw4Q==}
     peerDependencies:
       reflect-metadata: ~0.2.2
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -543,6 +836,9 @@ packages:
   jackspeak@4.1.0:
     resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
     engines: {node: 20 || >=22}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
@@ -553,6 +849,46 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
+    engines: {node: '>= 0.6'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
@@ -570,8 +906,30 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -581,6 +939,10 @@ packages:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
 
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -588,12 +950,105 @@ packages:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.1.1:
+    resolution: {integrity: sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==}
+
+  pg-connection-string@2.7.0:
+    resolution: {integrity: sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
+  pg-pool@3.8.0:
+    resolution: {integrity: sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.8.0:
+    resolution: {integrity: sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg-types@4.0.2:
+    resolution: {integrity: sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==}
+    engines: {node: '>=10'}
+
+  pg@8.14.1:
+    resolution: {integrity: sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
+    engines: {node: '>= 0.8'}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -608,6 +1063,27 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -615,6 +1091,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -627,8 +1119,16 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.8.1:
     resolution: {integrity: sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==}
@@ -649,6 +1149,14 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
 
+  superagent@9.0.2:
+    resolution: {integrity: sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.1.0:
+    resolution: {integrity: sha512-5QeSO8hSrKghtcWEoPiO036fxH0Ii2wVQfFZSP0oqQhmjk8bOLhDFXr4JrvaFmPuEWUoq4znY3uSi8UzLKxGqw==}
+    engines: {node: '>=14.18.0'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -666,6 +1174,24 @@ packages:
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
 
   turbo-darwin-64@2.4.4:
     resolution: {integrity: sha512-5kPvRkLAfmWI0MH96D+/THnDMGXlFNmjeqNRj5grLKiry+M9pKj3pRuScddAXPdlxjO5Ptz06UNaOQrrYGTx1g==}
@@ -701,6 +1227,10 @@ packages:
     resolution: {integrity: sha512-N9FDOVaY3yz0YCOhYIgOGYad7+m2ptvinXygw27WPLQvcZDl3+0Sa77KGVlLSiuPDChOUEnTKE9VJwLSi9BPGQ==}
     hasBin: true
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -708,6 +1238,17 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.0.8:
     resolution: {integrity: sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==}
@@ -800,6 +1341,20 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+  zod@3.24.2:
+    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
 snapshots:
 
   '@biomejs/biome@1.9.4':
@@ -836,6 +1391,10 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@esbuild/aix-ppc64@0.25.1':
     optional: true
@@ -946,7 +1505,14 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@rollup/rollup-android-arm-eabi@4.35.0':
     optional: true
@@ -1005,11 +1571,66 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.35.0':
     optional: true
 
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/body-parser@1.19.5':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.13.10
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.13.10
+
   '@types/estree@1.0.6': {}
+
+  '@types/express-serve-static-core@5.0.6':
+    dependencies:
+      '@types/node': 22.13.10
+      '@types/qs': 6.9.18
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.4
+
+  '@types/express@5.0.1':
+    dependencies:
+      '@types/body-parser': 1.19.5
+      '@types/express-serve-static-core': 5.0.6
+      '@types/serve-static': 1.15.7
+
+  '@types/http-errors@2.0.4': {}
+
+  '@types/mime@1.3.5': {}
 
   '@types/node@22.13.10':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/pg@8.11.11':
+    dependencies:
+      '@types/node': 22.13.10
+      pg-protocol: 1.8.0
+      pg-types: 4.0.2
+
+  '@types/qs@6.9.18': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@0.17.4':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 22.13.10
+
+  '@types/serve-static@1.15.7':
+    dependencies:
+      '@types/http-errors': 2.0.4
+      '@types/node': 22.13.10
+      '@types/send': 0.17.4
 
   '@vitest/expect@3.0.8':
     dependencies:
@@ -1051,6 +1672,17 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
+
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.14.1
+
+  acorn@8.14.1: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
@@ -1061,15 +1693,47 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  arg@4.1.3: {}
+
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   balanced-match@1.0.2: {}
+
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.0
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.0
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@5.2.0:
     dependencies:
@@ -1087,6 +1751,26 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  component-emitter@1.3.1: {}
+
+  content-disposition@1.0.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
+
+  create-require@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1099,13 +1783,49 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
+
+  diff@4.0.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
 
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.6.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.1:
     optionalDependencies:
@@ -1135,19 +1855,105 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.1
       '@esbuild/win32-x64': 0.25.1
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
 
+  etag@1.8.1: {}
+
   expect-type@1.2.0: {}
+
+  express@5.1.0:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.1
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-safe-stringify@2.1.1: {}
+
+  finalhandler@2.1.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data@4.0.2:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+
+  formidable@3.5.2:
+    dependencies:
+      dezalgo: 1.0.4
+      hexoid: 2.0.0
+      once: 1.4.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   glob@11.0.1:
     dependencies:
@@ -1158,6 +1964,34 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hexoid@2.0.0: {}
+
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
   inversify@7.1.0(reflect-metadata@0.2.2):
     dependencies:
       '@inversifyjs/common': 1.5.0
@@ -1165,13 +1999,19 @@ snapshots:
       '@inversifyjs/core': 5.0.0(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
 
+  ipaddr.js@1.9.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
 
   jackspeak@4.1.0:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  jsonc-parser@3.3.1: {}
 
   loupe@3.1.3: {}
 
@@ -1180,6 +2020,30 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  make-error@1.3.6: {}
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
+
+  mime@2.6.0: {}
 
   minimatch@10.0.1:
     dependencies:
@@ -1191,7 +2055,23 @@ snapshots:
 
   nanoid@3.3.9: {}
 
+  negotiator@1.0.0: {}
+
+  object-inspect@1.13.4: {}
+
+  obuf@1.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   package-json-from-dist@1.0.1: {}
+
+  parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
 
@@ -1200,9 +2080,58 @@ snapshots:
       lru-cache: 11.0.2
       minipass: 7.1.2
 
+  path-to-regexp@8.2.0: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.0: {}
+
+  pg-cloudflare@1.1.1:
+    optional: true
+
+  pg-connection-string@2.7.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-numeric@1.0.2: {}
+
+  pg-pool@3.8.0(pg@8.14.1):
+    dependencies:
+      pg: 8.14.1
+
+  pg-protocol@1.8.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg-types@4.0.2:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+
+  pg@8.14.1:
+    dependencies:
+      pg-connection-string: 2.7.0
+      pg-pool: 3.8.0(pg@8.14.1)
+      pg-protocol: 1.8.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.1.1
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -1211,6 +2140,46 @@ snapshots:
       nanoid: 3.3.9
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
+  postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      unpipe: 1.0.0
 
   reflect-metadata@0.2.2: {}
 
@@ -1244,11 +2213,80 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.35.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.0
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -1256,7 +2294,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  split2@4.2.0: {}
+
   stackback@0.0.2: {}
+
+  statuses@2.0.1: {}
 
   std-env@3.8.1: {}
 
@@ -1280,6 +2322,27 @@ snapshots:
     dependencies:
       ansi-regex: 6.1.0
 
+  superagent@9.0.2:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.0
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.2
+      formidable: 3.5.2
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.14.0
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.1.0:
+    dependencies:
+      methods: 1.1.2
+      superagent: 9.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -1289,6 +2352,26 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@3.0.2: {}
+
+  toidentifier@1.0.1: {}
+
+  ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.13.10
+      acorn: 8.14.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   turbo-darwin-64@2.4.4:
     optional: true
@@ -1317,9 +2400,21 @@ snapshots:
       turbo-windows-64: 2.4.4
       turbo-windows-arm64: 2.4.4
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
+
   typescript@5.8.2: {}
 
   undici-types@6.20.0: {}
+
+  unpipe@1.0.0: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  vary@1.1.2: {}
 
   vite-node@3.0.8(@types/node@22.13.10):
     dependencies:
@@ -1409,3 +2504,11 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
+
+  wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
+
+  yn@3.1.1: {}
+
+  zod@3.24.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "recipes/*"

--- a/recipes/express-example/README.md
+++ b/recipes/express-example/README.md
@@ -1,0 +1,186 @@
+# TypeWire Express Example
+
+This recipe demonstrates how to use TypeWire in an Express.js application, showcasing dependency injection and service organization.
+
+## Project Structure
+
+```
+src/
+├── config/           # Configuration management
+├── db/              # Database connections and utilities
+├── routes/          # Express routes
+├── services/        # Business logic and services
+├── main.ts          # Application entry point
+└── main.wires.ts    # Wire definitions and groupings
+```
+
+## Key Concepts
+
+### Wire Definitions
+
+TypeWire uses explicit wire definitions to manage dependencies. Each service typically has:
+
+1. An interface file (e.g., `user-service.ts`):
+```typescript
+export interface User {
+  id: string;
+  name: string;
+  age: number;
+}
+
+export interface UserService {
+  getUserById(id: string): Promise<User | undefined>;
+  save(user: User): Promise<void>;
+}
+```
+
+2. Implementation files (e.g., `user-service.memory.ts`):
+```typescript
+import type { User } from "./user-service";
+import { typeWireOf } from "@typewirets/core";
+
+export class InMemoryUserService {
+  constructor(private readonly userStore: Record<string, User> = {}) {}
+
+  async getUserById(id: string): Promise<User | undefined> {
+    return this.userStore[id];
+  }
+
+  async save(user: User) {
+    this.userStore[user.id] = user;
+  }
+}
+
+export const InMemoryUserServiceWire = typeWireOf({
+  token: "InMemoryUserService",
+  creator() {
+    return new InMemoryUserService();
+  },
+});
+```
+
+3. Interface wire file (e.g., `user-service.wire.ts`):
+```typescript
+import { typeWireOf } from "@typewirets/core";
+import type { UserService } from "./user-service";
+import { InMemoryUserServiceWire } from "./user-service.memory";
+
+export const UserServiceWire = typeWireOf<UserService>({
+  token: "UserServiceWire",
+  async creator(ctx) {
+    return InMemoryUserServiceWire.getInstance(ctx);
+  },
+});
+```
+
+### Wire Grouping
+
+Wires can be grouped for better organization and initialization:
+
+```typescript
+// main.wires.ts
+import { typeWireOf } from "@typewirets/core";
+
+export const PreloadWires = [
+  JsoncConfigRecordWire,
+  ConfigServiceWire,
+];
+
+export const AppWires = [
+  UserServiceWire,
+  InMemoryUserServiceWire,
+  SaveUserRouteWire,
+  GetUserRouteWire,
+];
+```
+
+### Async vs Sync Access
+
+TypeWire provides both async and sync access patterns:
+
+```typescript
+// Async access (default)
+const userService = await container.getInstance(UserServiceWire);
+
+// Sync access (requires preloading)
+try {
+  const userService = container.getInstanceSync(UserServiceWire);
+} catch (error) {
+  // Handle error if wire wasn't preloaded
+}
+```
+
+## Example Usage
+
+### Express Route
+```typescript
+import { typeWireOf } from "@typewirets/core";
+import type { Request, Response } from "express";
+import type { UserService } from "../services/user-service";
+
+export const SaveUserRouteWire = typeWireOf({
+  token: "SaveUserRoute",
+  async creator(ctx) {
+    const userService = await UserServiceWire.getInstance(ctx);
+    return async (req: Request, res: Response) => {
+      const user = req.body;
+      await userService.save(user);
+      res.status(201).send();
+    };
+  },
+});
+```
+
+### Application Setup
+```typescript
+async function main() {
+  const container = new TypeWireContainer();
+
+  // Load configuration first
+  await loadWires(container, PreloadWires);
+  
+  // Then load application wires
+  await loadWires(container, AppWires);
+  
+  const config = await ConfigServiceWire.getInstance(container);
+  const app = express();
+
+  app.use(express.json());
+  await loadRoutes(app, container);
+
+  const port = config.get("server.port") ?? 3000;
+  app.listen(port);
+}
+
+main();
+```
+
+## Error Handling
+
+1. **Sync Access Errors**
+```typescript
+try {
+  const service = container.getInstanceSync(ServiceWire);
+} catch (error) {
+  if (error instanceof NotPreloadedError) {
+    // Handle not preloaded case
+  }
+}
+```
+
+2. **Async Errors**
+```typescript
+try {
+  const service = await container.getInstance(ServiceWire);
+} catch (error) {
+  // Handle async error
+}
+```
+
+## Contributing
+
+Feel free to submit issues and enhancement requests.
+
+## License
+
+This project is licensed under the MIT License. 

--- a/recipes/express-example/config.jsonc
+++ b/recipes/express-example/config.jsonc
@@ -1,0 +1,6 @@
+{
+  // server config
+  "server": {
+    "port": 3000
+  }
+}

--- a/recipes/express-example/package.json
+++ b/recipes/express-example/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@typewirets/express-example",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Express Example",
+  "scripts": {
+    "clean": "rimraf dist",
+    "check-types": "tsc --noEmit",
+    "start": "pnpm dlx tsx ./src/main.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Rex Kim",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typewirets/typewirets.git",
+    "directory": "recipes/express-example"
+  },
+  "bugs": {
+    "url": "https://github.com/typewirets/typewirets/issues"
+  },
+  "homepage": "https://github.com/typewirets/typewirets#readme",
+  "devDependencies": {
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.13.10",
+    "@types/pg": "^8.11.11",
+    "@typewirets/typescript-config": "workspace:*",
+    "rimraf": "^6.0.1",
+    "supertest": "^7.1.0",
+    "ts-node": "^10.9.2",
+    "typescript": "5.8.2",
+    "vitest": "^3.0.8"
+  },
+  "dependencies": {
+    "@typewirets/core": "workspace:*",
+    "express": "^5.1.0",
+    "jsonc-parser": "^3.3.1",
+    "pg": "^8.14.1",
+    "zod": "^3.24.2"
+  }
+}

--- a/recipes/express-example/src/config/config-record.jsonc.wire.ts
+++ b/recipes/express-example/src/config/config-record.jsonc.wire.ts
@@ -1,0 +1,15 @@
+import { typeWireOf } from "@typewirets/core";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as JSONC from "jsonc-parser";
+
+export const JsoncConfigRecordWire = typeWireOf({
+  token: "JsoncConfigService",
+  async creator() {
+    const configPath = path.join(process.cwd(), "config.jsonc");
+    const configContent = await fs.readFile(configPath, "utf-8");
+    const parsed = JSONC.parse(configContent);
+    // biome-ignore lint/suspicious/noExplicitAny: We don't know this in runtime
+    return parsed as Record<string, any>;
+  },
+});

--- a/recipes/express-example/src/config/config-service.ts
+++ b/recipes/express-example/src/config/config-service.ts
@@ -1,0 +1,41 @@
+export class ConfigService {
+  // biome-ignore lint/suspicious/noExplicitAny: config should have any
+  constructor(private readonly record: Record<string, any>) {}
+
+  // biome-ignore lint/suspicious/noExplicitAny: parsed config must get resolved at runtime.
+  private getAnyValue(keys: string[]): any | undefined {
+    // biome-ignore lint/suspicious/noExplicitAny: parsed config must get resolved at runtime.
+    let cur: any | undefined = this.record;
+    const keySize = keys.length;
+    for (let idx = 0; idx < keySize; idx++) {
+      if (Array.isArray(cur)) {
+        if (idx < keySize - 1) {
+          return;
+        }
+      }
+
+      if (typeof cur === "object") {
+        const key = keys[idx] as string;
+        cur = cur[key];
+      }
+    }
+
+    return cur;
+  }
+
+  get<T>(key: string): T {
+    if (!key) {
+      throw Error("empty key is not allowed");
+    }
+
+    return this.getAnyValue(key.split(".")) as T;
+  }
+
+  getSlice<T>(key: string): T[] {
+    if (!key) {
+      throw Error("empty key is not allowed");
+    }
+
+    return this.getAnyValue(key.split(".")) as T[];
+  }
+}

--- a/recipes/express-example/src/config/config-service.wire.ts
+++ b/recipes/express-example/src/config/config-service.wire.ts
@@ -1,0 +1,13 @@
+import { typeWireOf } from "@typewirets/core";
+import { JsoncConfigRecordWire } from "./config-record.jsonc.wire";
+import { ConfigService } from "./config-service";
+
+export const ConfigServiceWire = typeWireOf({
+  token: "ConfigService",
+  async creator(ctx) {
+    // if you change your mind to use YAML or TOML... etc
+    // come here and swap the wire
+    const record = await JsoncConfigRecordWire.getInstance(ctx);
+    return new ConfigService(record);
+  },
+});

--- a/recipes/express-example/src/db/pg.wire.ts
+++ b/recipes/express-example/src/db/pg.wire.ts
@@ -1,0 +1,27 @@
+import { ConfigServiceWire } from "../config/config-service.wire";
+import { typeWireOf } from "@typewirets/core";
+import { z } from "zod";
+import * as pg from "pg";
+
+export const DbConfigSchema = z.object({
+  host: z.string(),
+  user: z.string().optional(),
+  port: z.number().optional(),
+  password: z.string().optional(),
+  database: z.string().optional(),
+  connectionTimeoutMillis: z.number().optional(),
+  idleTimeoutMillis: z.number().optional(),
+  max: z.number().optional(),
+  allowExitOnIdle: z.boolean().optional(),
+});
+
+export const PgPoolWire = typeWireOf({
+  token: "PgPool",
+  async creator(ctx) {
+    const config = await ConfigServiceWire.getInstance(ctx);
+    const postgreConfig = DbConfigSchema.parse(
+      config.get("datasources.postgres"),
+    );
+    return new pg.Pool(postgreConfig);
+  },
+});

--- a/recipes/express-example/src/main.ts
+++ b/recipes/express-example/src/main.ts
@@ -1,0 +1,34 @@
+import express from "express";
+import { TypeWireContainer, combineWireGroups } from "@typewirets/core";
+import { PreloadWires, AppWires } from "./main.wires";
+import { ConfigServiceWire } from "./config/config-service.wire";
+import { loadRoutes } from "./routes/routes";
+
+async function main() {
+  const container = new TypeWireContainer();
+
+  const wireGroup = combineWireGroups([PreloadWires, AppWires]);
+  await wireGroup.apply(container);
+
+  const config = await ConfigServiceWire.getInstance(container);
+  const app = express();
+
+  // configure middlewares
+  app.use(express.json());
+
+  // configure routers
+  await loadRoutes(app, container);
+
+  // start app
+  const port = config.get("server.port") ?? 3000;
+  app.listen(port, (err) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+
+    console.log(`Listening on port: ${port}`);
+  });
+}
+
+main();

--- a/recipes/express-example/src/main.wires.ts
+++ b/recipes/express-example/src/main.wires.ts
@@ -1,0 +1,23 @@
+import { typeWireGroupOf } from "@typewirets/core";
+import { JsoncConfigRecordWire } from "./config/config-record.jsonc.wire";
+import { ConfigServiceWire } from "./config/config-service.wire";
+import { SaveUserRouteWire } from "./routes/save-user.route";
+import { GetUserRouteWire } from "./routes/get-user.route";
+import { UserServiceWire } from "./services/user-service.wire";
+import { InMemoryUserServiceWire } from "./services/user-service.memory";
+// import { PgPoolWire } from "./db/pg.wire";
+
+export const PreloadWires = typeWireGroupOf([
+  JsoncConfigRecordWire,
+  ConfigServiceWire,
+]);
+
+export const AppWires = typeWireGroupOf([
+  UserServiceWire,
+  InMemoryUserServiceWire,
+  SaveUserRouteWire,
+  GetUserRouteWire,
+  // add pg wire if need to be updated
+  // or perhaps conditionally load based of config later.
+  // PgPoolWire
+]);

--- a/recipes/express-example/src/routes/get-user.route.ts
+++ b/recipes/express-example/src/routes/get-user.route.ts
@@ -1,0 +1,41 @@
+import type { Request, Response } from "express";
+import { z, ZodError } from "zod";
+import { typeWireOf } from "@typewirets/core";
+import { UserServiceWire } from "../services/user-service.wire";
+
+export const UserRequestByIdSchema = z.object({
+  id: z.string(),
+});
+
+// showing a simple example of embedded wire and implementation
+export const GetUserRouteWire = typeWireOf({
+  token: "GetUserRoute",
+  async creator(ctx) {
+    const userService = await UserServiceWire.getInstance(ctx);
+
+    // recommended route
+    // /api/users/:id
+    return async (req: Request, res: Response) => {
+      try {
+        const params = UserRequestByIdSchema.parse(req.params);
+        const user = await userService.getUserById(params.id);
+        if (!user) {
+          // not found
+          res.status(404).end();
+          return;
+        }
+
+        res.json(user);
+      } catch (err: unknown) {
+        if (err instanceof ZodError) {
+          // validation error
+          res.status(400).json({ errors: err.errors });
+          return;
+        }
+
+        // throw unknown error so that express can handle it accordingly
+        throw err;
+      }
+    };
+  },
+});

--- a/recipes/express-example/src/routes/routes.ts
+++ b/recipes/express-example/src/routes/routes.ts
@@ -1,0 +1,12 @@
+import type { Application } from "express";
+import type { ResolutionContext } from "@typewirets/core";
+import { GetUserRouteWire } from "./get-user.route";
+import { SaveUserRouteWire } from "./save-user.route";
+
+export async function loadRoutes(app: Application, ctx: ResolutionContext) {
+  const getUserRoute = await GetUserRouteWire.getInstance(ctx);
+  const saveUserRoute = await SaveUserRouteWire.getInstance(ctx);
+
+  app.get("/api/users/:id", getUserRoute);
+  app.post("/api/users", saveUserRoute);
+}

--- a/recipes/express-example/src/routes/save-user.route.ts
+++ b/recipes/express-example/src/routes/save-user.route.ts
@@ -1,0 +1,37 @@
+import type { Request, Response } from "express";
+import { z, ZodError } from "zod";
+import { typeWireOf } from "@typewirets/core";
+import { UserServiceWire } from "../services/user-service.wire";
+
+export const SaveUserRequest = z.object({
+  id: z.string(),
+  name: z.string(),
+  age: z.number(),
+});
+
+// showing a simple example of embedded wire and implementation
+export const SaveUserRouteWire = typeWireOf({
+  token: "SaveUserRouter",
+  async creator(ctx) {
+    const userService = await UserServiceWire.getInstance(ctx);
+
+    // recommended route
+    // POST /api/users
+    return async (req: Request, res: Response) => {
+      try {
+        const user = SaveUserRequest.parse(req.body);
+        await userService.save(user);
+        res.end();
+      } catch (err: unknown) {
+        if (err instanceof ZodError) {
+          // validation error
+          res.status(400).json({ errors: err.errors });
+          return;
+        }
+
+        // throw unknown error so that express can handle it accordingly
+        throw err;
+      }
+    };
+  },
+});

--- a/recipes/express-example/src/services/user-service.memory.ts
+++ b/recipes/express-example/src/services/user-service.memory.ts
@@ -1,0 +1,21 @@
+import type { User } from "./user-service";
+import { typeWireOf } from "@typewirets/core";
+
+export class InMemoryUserService {
+  constructor(private readonly userStore: Record<string, User> = {}) {}
+
+  async getUserById(id: string): Promise<User | undefined> {
+    return this.userStore[id];
+  }
+
+  async save(user: User) {
+    this.userStore[user.id] = user;
+  }
+}
+
+export const InMemoryUserServiceWire = typeWireOf({
+  token: "InMemoryUserService",
+  creator() {
+    return new InMemoryUserService();
+  },
+});

--- a/recipes/express-example/src/services/user-service.pg.ts
+++ b/recipes/express-example/src/services/user-service.pg.ts
@@ -1,0 +1,42 @@
+import { PgPoolWire } from "../db/pg.wire";
+import type { User, UserService } from "./user-service";
+import { typeWireOf } from "@typewirets/core";
+
+export const PgUserServiceWire = typeWireOf({
+  token: "PgUserService",
+  // embedded style
+  // if you do not mind mixing implementation with wire
+  async creator(ctx) {
+    const pgPool = await PgPoolWire.getInstance(ctx);
+    return {
+      async getUserById(id: string) {
+        const client = await pgPool.connect();
+        try {
+          const res = await client.query(
+            "SELECT * FROM users WHERE id = $1 LIMIT 1 ",
+            [id],
+          );
+
+          if (res.rowCount === 1) {
+            return res.rows[0] as User;
+          }
+        } finally {
+          client.release();
+        }
+      },
+
+      async save(user: User) {
+        const client = await pgPool.connect();
+        try {
+          const { id, name, age } = user;
+          await client.query(
+            "INSERT INTO users (id, name, age) VALUSE($1, $2, $3)",
+            [id, name, age],
+          );
+        } finally {
+          client.release();
+        }
+      },
+    } satisfies UserService;
+  },
+});

--- a/recipes/express-example/src/services/user-service.test.ts
+++ b/recipes/express-example/src/services/user-service.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { TypeWireContainer } from "@typewirets/core";
+import { UserServiceWire } from "./user-service.wire";
+import { InMemoryUserServiceWire } from "./user-service.memory";
+import type { User, UserService } from "./user-service";
+
+describe("UserService", () => {
+  let container: TypeWireContainer;
+  let userService: UserService;
+
+  beforeEach(async () => {
+    container = new TypeWireContainer();
+    await InMemoryUserServiceWire.apply(container);
+    await UserServiceWire.apply(container);
+    userService = await UserServiceWire.getInstance(container);
+  });
+
+  it("should save and retrieve a user", async () => {
+    const user: User = {
+      id: "1",
+      name: "John Doe",
+      age: 30,
+    };
+
+    await userService.save(user);
+    const retrievedUser = await userService.getUserById("1");
+
+    expect(retrievedUser).toEqual(user);
+  });
+
+  it("should return undefined when user is not found", async () => {
+    const user = await userService.getUserById("non-existent");
+    expect(user).toBeUndefined();
+  });
+});

--- a/recipes/express-example/src/services/user-service.ts
+++ b/recipes/express-example/src/services/user-service.ts
@@ -1,0 +1,10 @@
+export interface User {
+  id: string;
+  name: string;
+  age: number;
+}
+
+export interface UserService {
+  getUserById(id: string): Promise<User | undefined>;
+  save(user: User): Promise<void>;
+}

--- a/recipes/express-example/src/services/user-service.wire.ts
+++ b/recipes/express-example/src/services/user-service.wire.ts
@@ -1,0 +1,10 @@
+import { typeWireOf } from "@typewirets/core";
+import type { UserService } from "./user-service";
+import { InMemoryUserServiceWire } from "./user-service.memory";
+
+export const UserServiceWire = typeWireOf<UserService>({
+  token: "UserServiceWire",
+  async creator(ctx) {
+    return InMemoryUserServiceWire.getInstance(ctx);
+  },
+});

--- a/recipes/express-example/tsconfig.build.json
+++ b/recipes/express-example/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "node_modules"
+  ]
+}

--- a/recipes/express-example/tsconfig.json
+++ b/recipes/express-example/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@typewirets/typescript-config/base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "isolatedModules": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/recipes/express-example/vitest.config.ts
+++ b/recipes/express-example/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      exclude: ["node_modules/", "src/**/*.test.ts"],
+    },
+  },
+});


### PR DESCRIPTION
Add parallel instance resolution capabilities to TypeWireGroup with both async and sync variants. This enables efficient pre-loading of async resources and fast synchronous access to singleton instances.

- Add getAllInstances for parallel async resolution
- Add getAllInstancesSync for synchronous access
- Update documentation with real-world usage examples
- Improve type safety and error handling
- Add comprehensive JSDoc with usage patterns

The new methods provide a more efficient way to resolve multiple instances in parallel, particularly useful for:
- Pre-loading async resources during startup
- Accessing pre-loaded singleton instances synchronously
- Managing groups of related services