### PR TITLE
[minor] Fix ResolutionMonitor and Add React SPA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@typewirets/typewirets",
+  "type": "module",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@typewirets/typewirets",
-  "type": "module",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,7 +10,18 @@ A lightweight, container-agnostic dependency injection library for TypeScript th
 - 🧩 **Immutable definitions** - Functional API for composing and reusing definitions
 - ⚡ **Async support** - First-class support for asynchronous dependency resolution
 - 🔍 **Circular dependency detection** - Automatically detects circular dependencies
-- 🧠 **Smart scoping** - Support for singleton, and transient scopes
+- 🧠 **Smart scoping** - Support for singleton and transient scopes
+
+## Why TypeWire?
+
+TypeWire is designed to shift focus from object creation to behavior composition. By abstracting away the complexities of instantiation, developers can:
+
+- **Focus on behavior rather than construction** - Write code that uses objects for what they do, not how they're created
+- **Compose behaviors more easily** - Build complex systems by combining simpler, well-defined components
+- **Separate concerns more cleanly** - Decouple what an object does from how it's created and configured
+- **Improve testability** - Replace real implementations with test doubles without changing consumer code
+
+The goal is to let you think more about interactions between components and less about their instantiation details, making your code more maintainable and your architecture more flexible.
 
 ## Installation
 
@@ -18,348 +29,91 @@ A lightweight, container-agnostic dependency injection library for TypeScript th
 npm install @typewirets/core
 ```
 
-## Basic Usage
+## Core Concepts
+
+### TypeSymbol
+
+A typed wrapper around JavaScript's Symbol that preserves type information at compile time.
 
 ```typescript
-import { typeWireOf, TypeWireContainer } from '@typewirets/core';
+import { typeSymbolOf } from '@typewirets/core';
 
-// Define your services
-class Logger {
-  log(message: string): void {
-    console.log(`[LOG] ${message}`);
-  }
-}
-
-class UserService {
-  constructor(private logger: Logger) {}
-
-  getUser(id: string): void {
-    this.logger.log(`Getting user with id: ${id}`);
-    // Implementation...
-  }
-}
-
-// Create TypeWire definitions
-const loggerWire = typeWireOf({
-  token: 'Logger',
-  creator: () => new Logger()
-});
-
-const userServiceWire = typeWireOf({
-  token: 'UserService',
-  creator: (ctx) => new UserService(loggerWire.getInstance(ctx))
-});
-
-// Create a container
-const container = new TypeWireContainer();
-
-// Register the dependencies (using async/await)
-async function setupContainer() {
-  await loggerWire.apply(container);
-  await userServiceWire.apply(container);
-  
-  // Resolve and use a service
-  const userService = userServiceWire.getInstance(container);
-  userService.getUser('123');
-}
-
-setupContainer();
+const userSymbol = typeSymbolOf<User>('User');
 ```
 
-## Scopes and Recommended Strategy
+### TypeWire
 
-TypeWire supports different scopes to control the lifecycle of your dependencies:
+Defines how to create and manage instances of a specific type.
 
 ```typescript
-// Singleton scope (default) - one instance for all resolutions
-const loggerWire = typeWireOf({
-  token: 'Logger',
-  creator: () => new Logger(),
-  scope: 'singleton'
+import { typeWireOf } from '@typewirets/core';
+
+const userWire = typeWireOf({
+  token: 'User',
+  creator: (ctx) => new User()
 });
-
-// Transient scope - new instance for each resolution
-const transientLogger = typeWireOf({
-  token: 'Logger',
-  creator: () => new Logger(),
-  scope: 'transient'
-});
-```
-
-### Recommended Scoping Strategy
-
-While TypeWire supports various scoping options, we recommend focusing primarily on:
-
-1. **Singleton scope** (default) for most dependencies
-2. **Transient scope** for specific use cases where isolation is required
-
-### Why We Encourage Singleton-First Approach:
-
-- **Reasoning Simplicity**: Singleton services create a clearer mental model of your application, making code easier to reason about and debug
-  
-- **Clean Separation of Concerns**: 
-  - Singleton services are ideal for encapsulating non-declarative, side-effect producing code
-  - This allows the rest of your application to remain more declarative and functional
-  
-- **Resource Management**: Singleton services better manage resources like connections, caches, and other expensive resources
-  
-- **Testability**: Services with explicit dependencies are easier to mock and test compared to those that rely on contextual information
-
-- **Domain Logic Isolation**: Singleton services provide natural boundaries for domain logic, improving maintainability
-
-### When to Use Transient Scope:
-
-- When a service must maintain internal state that cannot be shared
-- For factories that produce objects with different configurations
-- During testing to ensure isolation between test cases
-
-### Avoiding Request/Context Scopes:
-
-While other DI frameworks emphasize request-scoped dependencies, we believe this often leads to:
-
-1. Hidden dependencies on request context
-2. Harder-to-test code that relies on runtime context
-3. Less reusable components with implicit environmental requirements
-4. Blurred boundaries between application layers
-
-Instead, we recommend passing contextual information explicitly as method parameters when needed, keeping your dependency graph clean and explicit.
-
-## Async Dependencies
-
-TypeWire has first-class support for asynchronous dependencies:
-
-```typescript
-const databaseWire = typeWireOf({
-  token: 'Database',
-  creator: async () => {
-    const connection = await connectToDatabase();
-    return new Database(connection);
-  }
-});
-
-// Apply the definition (must use await)
-await databaseWire.apply(container);
-
-// Resolve asynchronously
-const database = await databaseWire.getInstanceAsync(container);
-```
-
-## Composing Definitions
-
-TypeWire definitions are immutable, allowing for easy composition. This is particularly useful for testing scenarios where you need to replace real implementations with mocks or add instrumentation:
-
-```typescript
-// Start with a basic definition
-const loggerWire = typeWireOf({
-  token: 'Logger',
-  creator: () => new Logger()
-});
-
-// For tests: Replace with a mock implementation
-const mockLoggerWire = loggerWire.withCreator(() => new MockLogger());
-
-// For tests: Add spy to monitor calls
-const spyLoggerWire = loggerWire.withCreator((ctx, original) => {
-  const logger = original(ctx);
-  jest.spyOn(logger, 'log');
-  return logger;
-});
-
-// Change scope for testing isolation
-const transientLoggerWire = loggerWire.withScope('transient');
-```
-
-**Important Note**: These definitions all share the same symbol (type identifier). When applied to a container, the last one applied will override any previous bindings with the same symbol:
-
-```typescript
-// In production code
-await loggerWire.apply(container);
-
-// In test code - this will replace the original binding
-await mockLoggerWire.apply(container);
-```
-
-If you need different bindings to coexist in the same container, you should create them with different tokens:
-
-```typescript
-const loggerWire = typeWireOf({
-  token: 'Logger',
-  creator: () => new Logger()
-});
-
-const debugLoggerWire = typeWireOf({
-  token: 'DebugLogger', // Different token = different symbol
-  creator: () => {
-    const logger = new Logger();
-    logger.level = 'debug';
-    return logger;
-  }
-});
-
-// Both can be registered without conflict
-await loggerWire.apply(container);
-await debugLoggerWire.apply(container);
-```
-
-## Core Interfaces
-
-### TypeWire<T>
-
-The central interface defining how to create and manage an instance of type `T`:
-
-```typescript
-interface TypeWire<T> {
-  readonly type: TypeSymbol<T>;
-  readonly scope?: string;
-  readonly creator: Creator<T>;
-  
-  apply(binder: BindingContext): Promise<void>;
-  getInstance(resolver: ResolutionContext): T;
-  getInstanceAsync(resolver: ResolutionContext): Promise<T>;
-  withScope(scope: string): TypeWire<T>;
-  withCreator(create: CreatorDecorator<T>): TypeWire<T>;
-}
-```
-
-### ResolutionContext
-
-Provides methods to resolve dependencies:
-
-```typescript
-interface ResolutionContext {
-  get<T>(symbol: TypedSymbol<T>): T;
-  getAsync<T>(symbol: TypedSymbol<T>): Promise<T>;
-}
-```
-
-### BindingContext
-
-Provides methods to register dependencies:
-
-```typescript
-interface BindingContext {
-  bind(typeWire: TypeWireDefinition<unknown>): void | Promise<void>;
-  unbind(symbol: TypedSymbol<unknown>): void;
-  isBound(symbol: TypedSymbol<unknown>): boolean;
-}
 ```
 
 ### TypeWireGroup
 
-A group of TypeWire instances that can be managed together. This interface extends `Applicable`, allowing you to apply all wires in the group at once.
+A collection of TypeWire instances that can be managed together.
 
 ```typescript
-interface TypeWireGroup<T> extends Applicable {
-  /**
-   * The array of TypeWire instances in this group.
-   */
-  wires: TypeWire<T>[];
-}
-```
+import { typeWireGroupOf, combineWireGroups } from '@typewirets/core';
 
-The library provides a standard implementation through `StandardTypeWireGroup`:
+// Create a group of wires
+const serviceWires = typeWireGroupOf([userWire, loggerWire]);
 
-```typescript
-class StandardTypeWireGroup<T> implements TypeWireGroup<T> {
-  constructor(readonly wires: TypeWire<T>[]) {}
-
-  async apply(binder: BindingContext) {
-    for (const wire of this.wires) {
-      await wire.apply(binder);
-    }
-  }
-}
-```
-
-You can create groups of wires using `typeWireGroupOf`:
-
-```typescript
-// Define a base type for your components
-interface Service {
-  start(): Promise<void>;
-}
-
-// Create typed wires for each service
-const DatabaseServiceWire = typeWireOf({
-  token: 'DatabaseService',
-  creator: () => new DatabaseService()
-});
-
-const CacheServiceWire = typeWireOf({
-  token: 'CacheService',
-  creator: () => new CacheService()
-});
-
-// Create a group of service wires
-const serviceWires = typeWireGroupOf([
-  DatabaseServiceWire,
-  CacheServiceWire
-]);
-
-// Apply all wires in the group at once
+// Apply all wires in the group
 await serviceWires.apply(container);
+
+// Combine multiple groups
+const allWires = combineWireGroups([coreWires, featureWires]);
 ```
 
-You can also combine multiple groups using `combineWireGroups`:
+### TypeWireContainer
+
+The default implementation of both ResolutionContext and BindingContext.
 
 ```typescript
-// Define your wire groups in separate files
-// core.wires.ts
-export const CoreWires = typeWireGroupOf([
-  UserServiceWire,
-  AuthServiceWire
-]);
+import { TypeWireContainer } from '@typewirets/core';
 
-// feature.wires.ts
-export const FeatureWires = typeWireGroupOf([
-  FeatureServiceWire,
-  FeatureControllerWire
-]);
+const container = new TypeWireContainer();
 
-// Combine them in your app setup
-const allWires = combineWireGroups([
-  CoreWires,
-  FeatureWires
-]);
+// Register dependencies
+await userWire.apply(container);
 
-// Apply all wires at once
-await allWires.apply(container);
+// Resolve instances
+const user = await userWire.getInstance(container);
+const syncUser = userWire.getInstanceSync(container);
 ```
 
-The `TypeWireGroup` interface provides several benefits:
-1. **Type Safety**: All wires in the group must create instances of the same type
-2. **Convenience**: Apply all wires in a group with a single call
-3. **Organization**: Group related wires together for better code organization
-4. **Composition**: Combine multiple groups into larger groups as needed
-5. **Debugging**: The standard implementation makes it easy to debug wire groups
+## Best Practices
 
-## Error Handling
+1. **Singleton-First Approach**:
+   - Use singleton scope for most services
+   - Makes code easier to reason about
+   - Better resource management
+   - Clearer separation of concerns
+   - **Encourages behavior abstraction** - When working with singletons, developers naturally focus on what objects do rather than how they're constructed
+   - **Promotes composition** - Singletons make it easier to compose behaviors by providing stable references to components
+   - **Shifts focus from creation to usage** - The emphasis moves from object instantiation to object interaction and behavior
 
-TypeWire provides clear error messages to help with debugging dependency issues. The error messages follow this format:
+2. **Explicit Dependencies**:
+   - Pass dependencies explicitly
+   - Avoid request/context scopes
+   - Makes testing easier
+   - Improves code maintainability
 
-```
-[Error Type] Error resolving [ServiceName]
-Path: ServiceA -> ServiceB -> ServiceC
-Resolution: [Specific instructions based on error type]
-```
+3. **Async Initialization**:
+   - Handle async setup in creators
+   - Use getAllInstances for parallel loading
+   - Cache results for better performance
 
-The error messages are designed to be:
-- Clear and actionable
-- Include the full dependency path
-- Provide specific resolution instructions
-- Easy to parse for error tracking tools
-
-You can customize how many path items are shown in error messages:
-
-```typescript
-const container = new TypeWireContainer({
-  numberOfPathsToPrint: 5 // Limit path length in error messages
-});
-```
-
-## Ecosystem Comparison
-
-For a detailed comparison of TypeWire with other DI solutions, including bundle size comparisons and key differentiators, see our [Ecosystem Comparison](docs/ecosystem-comparison.md) documentation.
+4. **Type Safety**:
+   - Define clear interfaces
+   - Use type inference where possible
+   - Leverage TypeScript's type system
 
 ## License
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -500,7 +500,7 @@ export class StandardTypeWire<T> implements TypeWire<T> {
     }
 
     if (binder.isBound(this.type)) {
-      binder.unbind(this.type);
+      await binder.unbind(this.type);
     }
 
     binder.bind(this);

--- a/packages/inversify/src/index.ts
+++ b/packages/inversify/src/index.ts
@@ -1,17 +1,30 @@
 import type {
-  Container,
-  ResolutionContext as InnversifyResolutionContext,
-  ContainerModuleLoadOptions,
-  BindingScope,
-} from "inversify";
-import type {
-  TypeSymbol,
   AnyTypeSymbol,
   AnyTypeWire,
-  ResolutionContext as TypeWireResolutionContext,
   BindingContext,
+  TypeSymbol,
+  TypeWire,
+  ResolutionContext as TypeWireResolutionContext,
 } from "@typewirets/core";
+import type {
+  BindingScope,
+  Container,
+  ContainerModuleLoadOptions,
+  ResolutionContext as InnversifyResolutionContext,
+} from "inversify";
 
+/**
+ * Converts a TypeWire scope string to the equivalent InversifyJS BindingScope.
+ *
+ * @param scope - The TypeWire scope string (e.g., 'singleton', 'transient', 'request')
+ * @returns The equivalent InversifyJS BindingScope or undefined if no conversion is possible
+ *
+ * @example
+ * ```typescript
+ * // Convert a TypeWire scope to InversifyJS scope
+ * const inversifyScope = adoptScope('singleton'); // returns 'Singleton'
+ * ```
+ */
 export function adoptScope(scope?: string): BindingScope | undefined {
   if (!scope) {
     return undefined;
@@ -27,98 +40,195 @@ export function adoptScope(scope?: string): BindingScope | undefined {
   }
 }
 
-export function adaptToResolutionContext(
-  container: Container | InnversifyResolutionContext,
-): TypeWireResolutionContext {
-  return {
-    getSync<T>(typeSymbol: TypeSymbol<T>): T {
-      return container.get(typeSymbol.symbol);
-    },
-    get<T>(typeSymbol: TypeSymbol<T>): Promise<T> {
-      return container.getAsync(typeSymbol.symbol);
-    },
-  } satisfies TypeWireResolutionContext;
-}
-
-export function adaptToBindingContext(
-  container: Container | ContainerModuleLoadOptions,
-): BindingContext {
-  return {
-    bind(binding: AnyTypeWire) {
-      const bound = container
-        .bind(binding.type.symbol)
-        .toDynamicValue((ctx) => {
-          const tCtx = adaptToResolutionContext(ctx);
-          return binding.creator(tCtx);
-        });
-
-      const scope = adoptScope(binding.scope);
-      if (scope) {
-        switch (scope) {
-          case "Singleton":
-            bound.inSingletonScope();
-            break;
-          case "Transient":
-            bound.inTransientScope();
-            break;
-          case "Request":
-            bound.inRequestScope();
-        }
-      }
-    },
-
-    async unbind(typeSymbol: AnyTypeSymbol): Promise<void> {
-      await container.unbind(typeSymbol.symbol);
-    },
-
-    isBound(typeSymbol: AnyTypeSymbol): boolean {
-      return container.isBound(typeSymbol.symbol);
-    },
-  } satisfies BindingContext;
-}
-
 /**
  * Adapter class that provides both TypeWire ResolutionContext and BindingContext
- * interfaces on top of an Inversify container.
+ * interfaces on top of an InversifyJS container.
+ *
+ * This adapter allows TypeWire definitions to work with an existing InversifyJS
+ * container, providing a bridge between the two dependency injection systems.
+ *
+ * @example
+ * ```typescript
+ * const container = new Container();
+ * const adapter = new InversifyAdapter(container);
+ *
+ * // Now you can use TypeWire with your InversifyJS container
+ * await serviceWire.apply(adapter);
+ * const service = await serviceWire.getInstance(adapter);
+ * ```
  */
 export class InversifyAdapter
   implements TypeWireResolutionContext, BindingContext
 {
-  private readonly resolutionContext: TypeWireResolutionContext;
-  readonly bindingContext: BindingContext;
+  /**
+   * Set of symbols for which instances have been loaded/initialized.
+   * Used to track which singleton instances have already been created.
+   */
+  private readonly loaded: Set<symbol> = new Set();
 
-  constructor(readonly container: Container) {
-    this.resolutionContext = adaptToResolutionContext(container);
-    this.bindingContext = adaptToBindingContext(container);
+  /**
+   * Set of symbols that represent singleton-scoped dependencies.
+   */
+  private readonly singletons: Set<symbol> = new Set();
+
+  /**
+   * Creates a new InversifyAdapter for the specified container.
+   *
+   * @param container - The InversifyJS container to adapt
+   */
+  constructor(readonly container: Container) {}
+
+  /**
+   * Checks if a symbol represents a singleton-scoped dependency.
+   *
+   * @param symbol - The symbol to check
+   * @returns True if the dependency is singleton-scoped, false otherwise
+   */
+  #isSingleton(symbol: symbol): boolean {
+    return this.singletons.has(symbol);
   }
 
+  /**
+   * Gets an instance of type T synchronously.
+   * For singleton-scoped dependencies, also tracks that they have been loaded.
+   *
+   * @template T - The type of instance to get
+   * @param typeSymbol - The type symbol identifying the dependency
+   * @returns An instance of type T
+   * @throws Error if the dependency cannot be resolved synchronously
+   */
   getSync<T>(typeSymbol: AnyTypeSymbol): T {
-    return this.resolutionContext.getSync(typeSymbol);
+    if (!this.#isSingleton(typeSymbol.symbol)) {
+      return this.container.get(typeSymbol.symbol);
+    }
+
+    const result = this.container.get(typeSymbol.symbol) as T;
+    this.loaded.add(typeSymbol.symbol);
+    return result;
   }
 
-  get<T>(typeSymbol: TypeSymbol<T>): Promise<T> {
-    return this.resolutionContext.get(typeSymbol);
+  /**
+   * Gets an instance of type T asynchronously.
+   * For singleton-scoped dependencies, also tracks that they have been loaded.
+   *
+   * @template T - The type of instance to get
+   * @param typeSymbol - The type symbol identifying the dependency
+   * @returns A promise that resolves to an instance of type T
+   * @throws Error if the dependency is not found
+   */
+  async get<T>(typeSymbol: TypeSymbol<T>): Promise<T> {
+    if (!this.#isSingleton(typeSymbol.symbol)) {
+      return this.container.getAsync(typeSymbol.symbol);
+    }
+
+    const result = await this.container.getAsync(typeSymbol.symbol);
+    this.loaded.add(typeSymbol.symbol);
+    return result as T;
   }
 
+  /**
+   * Checks if an instance of the specified TypeWire is already loaded.
+   * For singleton scopes, this checks if the instance exists in cache.
+   * For transient scopes, this always returns false.
+   *
+   * @param typeWire - The TypeWire to check
+   * @returns True if an instance is already loaded, false otherwise
+   */
+  hasInstance(typeWire: AnyTypeWire): boolean {
+    if (!this.#isSingleton(typeWire.type.symbol)) {
+      return false;
+    }
+
+    return this.loaded.has(typeWire.type.symbol);
+  }
+
+  /**
+   * Returns an existing instance without triggering instantiation.
+   * If no instance exists, returns undefined instead of creating one.
+   *
+   * @template T - The type of instance to find
+   * @param typeWire - The TypeWire to look up
+   * @returns An existing instance of type T, or undefined if none exists
+   */
+  findInstance<T>(typeWire: TypeWire<T>): T | undefined {
+    if (!this.hasInstance(typeWire)) {
+      return;
+    }
+
+    return this.getSync(typeWire.type);
+  }
+
+  /**
+   * Binds a TypeWire to the InversifyJS container.
+   * Configures the binding with the appropriate scope and creator function.
+   *
+   * @param typeWire - The TypeWire to bind
+   */
   bind(typeWire: AnyTypeWire): void | Promise<void> {
-    return this.bindingContext.bind(typeWire);
+    const bound = this.container
+      .bind(typeWire.type.symbol)
+      .toDynamicValue((_ctx) => {
+        return typeWire.creator(this);
+      });
+
+    const scope = adoptScope(typeWire.scope);
+    if (scope) {
+      switch (scope) {
+        case "Singleton":
+          this.singletons.add(typeWire.type.symbol);
+          bound.inSingletonScope();
+          break;
+        case "Transient":
+          bound.inTransientScope();
+          break;
+        case "Request":
+          bound.inRequestScope();
+      }
+    }
   }
 
+  /**
+   * Removes a binding from the InversifyJS container.
+   * Also removes any tracking information for the binding.
+   *
+   * @param typeSymbol - The type symbol identifying the binding to remove
+   * @returns A promise that resolves when the unbinding is complete
+   */
   async unbind(typeSymbol: AnyTypeSymbol): Promise<void> {
-    await this.bindingContext.unbind(typeSymbol);
+    this.loaded.delete(typeSymbol.symbol);
+    this.singletons.delete(typeSymbol.symbol);
+    return this.container.unbind(typeSymbol.symbol);
   }
 
+  /**
+   * Checks if a binding exists in the InversifyJS container.
+   *
+   * @param typeSymbol - The type symbol to check
+   * @returns True if the binding exists, false otherwise
+   */
   isBound(typeSymbol: AnyTypeSymbol): boolean {
-    return this.bindingContext.isBound(typeSymbol);
+    return this.container.isBound(typeSymbol.symbol);
   }
 }
 
 /**
  * Creates an adapter that provides both TypeWire ResolutionContext and BindingContext
- * interfaces using an Inversify container.
+ * interfaces using an InversifyJS container.
  *
- * @param container The Inversify container to adapt
+ * This is a convenience function for creating an InversifyAdapter.
+ *
+ * @param container - The InversifyJS container to adapt
  * @returns An object implementing both TypeWire interfaces
+ *
+ * @example
+ * ```typescript
+ * const container = new Container();
+ * const adapter = createInversifyAdapter(container);
+ *
+ * // Now you can use TypeWire with your InversifyJS container
+ * await serviceWire.apply(adapter);
+ * const service = await serviceWire.getInstance(adapter);
+ * ```
  */
 export function createInversifyAdapter(
   container: Container,

--- a/packages/inversify/src/index.ts
+++ b/packages/inversify/src/index.ts
@@ -3,7 +3,6 @@ import type {
   AnyTypeWire,
   BindingContext,
   TypeSymbol,
-  TypeWire,
   ResolutionContext as TypeWireResolutionContext,
 } from "@typewirets/core";
 import type { BindingScope, Container } from "inversify";

--- a/packages/inversify/src/index.ts
+++ b/packages/inversify/src/index.ts
@@ -6,12 +6,7 @@ import type {
   TypeWire,
   ResolutionContext as TypeWireResolutionContext,
 } from "@typewirets/core";
-import type {
-  BindingScope,
-  Container,
-  ContainerModuleLoadOptions,
-  ResolutionContext as InnversifyResolutionContext,
-} from "inversify";
+import type { BindingScope, Container } from "inversify";
 
 /**
  * Converts a TypeWire scope string to the equivalent InversifyJS BindingScope.
@@ -27,7 +22,7 @@ import type {
  */
 export function adoptScope(scope?: string): BindingScope | undefined {
   if (!scope) {
-    return undefined;
+    return "Singleton";
   }
 
   switch (scope.toLowerCase()) {
@@ -124,38 +119,6 @@ export class InversifyAdapter
     const result = await this.container.getAsync(typeSymbol.symbol);
     this.loaded.add(typeSymbol.symbol);
     return result as T;
-  }
-
-  /**
-   * Checks if an instance of the specified TypeWire is already loaded.
-   * For singleton scopes, this checks if the instance exists in cache.
-   * For transient scopes, this always returns false.
-   *
-   * @param typeWire - The TypeWire to check
-   * @returns True if an instance is already loaded, false otherwise
-   */
-  hasInstance(typeWire: AnyTypeWire): boolean {
-    if (!this.#isSingleton(typeWire.type.symbol)) {
-      return false;
-    }
-
-    return this.loaded.has(typeWire.type.symbol);
-  }
-
-  /**
-   * Returns an existing instance without triggering instantiation.
-   * If no instance exists, returns undefined instead of creating one.
-   *
-   * @template T - The type of instance to find
-   * @param typeWire - The TypeWire to look up
-   * @returns An existing instance of type T, or undefined if none exists
-   */
-  findInstance<T>(typeWire: TypeWire<T>): T | undefined {
-    if (!this.hasInstance(typeWire)) {
-      return;
-    }
-
-    return this.getSync(typeWire.type);
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/node@22.13.10)
+        version: 3.0.8(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
 
   packages/inversify:
     dependencies:
@@ -63,7 +63,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/node@22.13.10)
+        version: 3.0.8(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
 
   packages/typescript-config: {}
 
@@ -111,9 +111,195 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/node@22.13.10)
+        version: 3.0.8(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+
+  recipes/react-trpc-fastify:
+    dependencies:
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
+      '@fastify/cors':
+        specifier: ^11.0.1
+        version: 11.0.1
+      '@fastify/session':
+        specifier: ^11.1.0
+        version: 11.1.0
+      '@tanstack/react-form':
+        specifier: ^1.3.2
+        version: 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
+      '@tanstack/react-query':
+        specifier: ^5.72.1
+        version: 5.72.1(react@19.1.0)
+      '@trpc/client':
+        specifier: ^11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.2))(typescript@5.8.2)
+      '@trpc/react-query':
+        specifier: ^11.0.4
+        version: 11.0.4(@tanstack/react-query@5.72.1(react@19.1.0))(@trpc/client@11.0.4(@trpc/server@11.0.4(typescript@5.8.2))(typescript@5.8.2))(@trpc/server@11.0.4(typescript@5.8.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
+      '@trpc/server':
+        specifier: ^11.0.4
+        version: 11.0.4(typescript@5.8.2)
+      '@trpc/tanstack-react-query':
+        specifier: ^11.0.4
+        version: 11.0.4(@tanstack/react-query@5.72.1(react@19.1.0))(@trpc/client@11.0.4(@trpc/server@11.0.4(typescript@5.8.2))(typescript@5.8.2))(@trpc/server@11.0.4(typescript@5.8.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
+      '@typewirets/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      arktype:
+        specifier: ^2.1.19
+        version: 2.1.19
+      fastify:
+        specifier: ^5.2.2
+        version: 5.2.2
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
+      sonner:
+        specifier: ^2.0.3
+        version: 2.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tailwindcss:
+        specifier: ^4.1.3
+        version: 4.1.3
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
+      zustand:
+        specifier: ^5.0.3
+        version: 5.0.3(@types/react@19.1.0)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
+    devDependencies:
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
+      '@tailwindcss/vite':
+        specifier: ^4.1.3
+        version: 4.1.3(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.14.0
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.1.0
+      '@types/react-dom':
+        specifier: ^19.1.0
+        version: 19.1.1(@types/react@19.1.0)
+      '@typewirets/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))
+      tsx:
+        specifier: ^4.19.3
+        version: 4.19.3
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.2
+      vite:
+        specifier: ^6.2.5
+        version: 6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))
+      vitest:
+        specifier: ^3.0.8
+        version: 3.0.8(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@ark/schema@0.45.9':
+    resolution: {integrity: sha512-rG0v/JI0sibn/0wERAHTYVLCtEqoMP2IIlxnb+S5DrEjCI5wpubbZSWMDW50tZ8tV6FANu6zzHDeeKbp6lsZdg==}
+
+  '@ark/util@0.45.9':
+    resolution: {integrity: sha512-0WYNAb8aRGp7dNt6xIvIrRzL7V1XL3u3PK2vcklhtTrdaP235DjC9qJhzidrxtWr68mA5ySSjUrgrXk622bKkw==}
+
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.26.8':
+    resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.26.10':
+    resolution: {integrity: sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.27.0':
+    resolution: {integrity: sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.0':
+    resolution: {integrity: sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.26.0':
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.26.5':
+    resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.27.0':
+    resolution: {integrity: sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.25.9':
+    resolution: {integrity: sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9':
+    resolution: {integrity: sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.27.0':
+    resolution: {integrity: sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.0':
+    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.0':
+    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
+    engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@1.9.4':
     resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
@@ -322,6 +508,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/ajv-compiler@4.0.2':
+    resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
+
+  '@fastify/cors@11.0.1':
+    resolution: {integrity: sha512-dmZaE7M1f4SM8ZZuk5RhSsDJ+ezTgI7v3HHRj8Ow9CneczsPLZV6+2j2uwdaSLn8zhTv6QV0F4ZRcqdalGx1pQ==}
+
+  '@fastify/error@4.1.0':
+    resolution: {integrity: sha512-KeFcciOr1eo/YvIXHP65S94jfEEqn1RxTRBT1aJaHxY5FK0/GDXYozsQMMWlZoHgi8i0s+YtrLsgj/JkUUjSkQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.0':
+    resolution: {integrity: sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.0.0':
+    resolution: {integrity: sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==}
+
+  '@fastify/session@11.1.0':
+    resolution: {integrity: sha512-OxAX79PtVyTKxfmHT8e0jDFliw/2EmhOxe1Mj35jhL20j8CEpj5Li2zOVi5PqHc5Y+7N2w0tOmtM8mB6NjAIGw==}
+
   '@inversifyjs/common@1.5.0':
     resolution: {integrity: sha512-Qj5BELk11AfI2rgZEAaLPmOftmQRLLmoCXgAjmaF0IngQN5vHomVT5ML7DZ3+CA5fgGcEVMcGbUDAun+Rz+oNg==}
 
@@ -345,15 +558,64 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jridgewell/gen-mapping@0.3.8':
+    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/set-array@1.2.1':
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/trace-mapping@0.3.25':
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@remix-run/node@2.16.5':
+    resolution: {integrity: sha512-awunS1kgFmc8q7sGz7FpGf66RXQm2Vw0yk5IFTIJa0WdQrskqyF/6CO+tEf/0np/OCu2fQ23+EfxY2qGHm1aOg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
+
+  '@remix-run/server-runtime@2.16.5':
+    resolution: {integrity: sha512-LGGNEJoior2zvgtqyPC5tVPucAvewovQvL4ztC5yE8ZszHmLri9bB9YYWvHqsiT+EaunKHNLmI8jpJHe3PEKhA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@remix-run/web-blob@3.1.0':
+    resolution: {integrity: sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==}
+
+  '@remix-run/web-fetch@4.4.2':
+    resolution: {integrity: sha512-jgKfzA713/4kAW/oZ4bC3MoLWyjModOVDjFPNseVqcJKSafgIscrYL9G50SurEYLswPuoU3HzSbO0jQCMYWHhA==}
+    engines: {node: ^10.17 || >=12.3}
+
+  '@remix-run/web-file@3.1.0':
+    resolution: {integrity: sha512-dW2MNGwoiEYhlspOAXFBasmLeYshyAyhIdrlXBi06Duex5tDr3ut2LFKVj7tyHLmn8nnNwFf1BjNbkQpygC2aQ==}
+
+  '@remix-run/web-form-data@3.1.0':
+    resolution: {integrity: sha512-NdeohLMdrb+pHxMQ/Geuzdp0eqPbea+Ieo8M8Jx2lGC6TBHsgHzYcBvr0LyPdPVycNRDEpWpiDdCOdCryo3f9A==}
+
+  '@remix-run/web-stream@1.1.0':
+    resolution: {integrity: sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==}
 
   '@rollup/rollup-android-arm-eabi@4.35.0':
     resolution: {integrity: sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ==}
@@ -450,6 +712,150 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@tailwindcss/node@4.1.3':
+    resolution: {integrity: sha512-H/6r6IPFJkCfBJZ2dKZiPJ7Ueb2wbL592+9bQEl2r73qbX6yGnmQVIfiUvDRB2YI0a3PWDrzUwkvQx1XW1bNkA==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.3':
+    resolution: {integrity: sha512-cxklKjtNLwFl3mDYw4XpEfBY+G8ssSg9ADL4Wm6//5woi3XGqlxFsnV5Zb6v07dxw1NvEX2uoqsxO/zWQsgR+g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.3':
+    resolution: {integrity: sha512-mqkf2tLR5VCrjBvuRDwzKNShRu99gCAVMkVsaEOFvv6cCjlEKXRecPu9DEnxp6STk5z+Vlbh1M5zY3nQCXMXhw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.3':
+    resolution: {integrity: sha512-7sGraGaWzXvCLyxrc7d+CCpUN3fYnkkcso3rCzwUmo/LteAl2ZGCDlGvDD8Y/1D3ngxT8KgDj1DSwOnNewKhmg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.3':
+    resolution: {integrity: sha512-E2+PbcbzIReaAYZe997wb9rId246yDkCwAakllAWSGqe6VTg9hHle67hfH6ExjpV2LSK/siRzBUs5wVff3RW9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.3':
+    resolution: {integrity: sha512-GvfbJ8wjSSjbLFFE3UYz4Eh8i4L6GiEYqCtA8j2Zd2oXriPuom/Ah/64pg/szWycQpzRnbDiJozoxFU2oJZyfg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.3':
+    resolution: {integrity: sha512-35UkuCWQTeG9BHcBQXndDOrpsnt3Pj9NVIB4CgNiKmpG8GnCNXeMczkUpOoqcOhO6Cc/mM2W7kaQ/MTEENDDXg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.3':
+    resolution: {integrity: sha512-dm18aQiML5QCj9DQo7wMbt1Z2tl3Giht54uVR87a84X8qRtuXxUqnKQkRDK5B4bCOmcZ580lF9YcoMkbDYTXHQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.3':
+    resolution: {integrity: sha512-LMdTmGe/NPtGOaOfV2HuO7w07jI3cflPrVq5CXl+2O93DCewADK0uW1ORNAcfu2YxDUS035eY2W38TxrsqngxA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.3':
+    resolution: {integrity: sha512-aalNWwIi54bbFEizwl1/XpmdDrOaCjRFQRgtbv9slWjmNPuJJTIKPHf5/XXDARc9CneW9FkSTqTbyvNecYAEGw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.3':
+    resolution: {integrity: sha512-PEj7XR4OGTGoboTIAdXicKuWl4EQIjKHKuR+bFy9oYN7CFZo0eu74+70O4XuERX4yjqVZGAkCdglBODlgqcCXg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.3':
+    resolution: {integrity: sha512-T8gfxECWDBENotpw3HR9SmNiHC9AOJdxs+woasRZ8Q/J4VHN0OMs7F+4yVNZ9EVN26Wv6mZbK0jv7eHYuLJLwA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.3':
+    resolution: {integrity: sha512-t16lpHCU7LBxDe/8dCj9ntyNpXaSTAgxWm1u2XQP5NiIu4KGSyrDJJRlK9hJ4U9yJxx0UKCVI67MJWFNll5mOQ==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/vite@4.1.3':
+    resolution: {integrity: sha512-lUI/QaDxLtlV52Lho6pu07CG9pSnRYLOPmKGIQjyHdTBagemc6HmgZxyjGAQ/5HMPrNeWBfTVIpQl0/jLXvWHQ==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6
+
+  '@tanstack/form-core@1.3.2':
+    resolution: {integrity: sha512-hqRLw9EJ8bLJ5zvorGgTI4INcKh1hAtjPRTslwdB529soP8LpguzqWhn7yVV5/c2GcMSlqmpy5NZarkF5Mf54A==}
+
+  '@tanstack/query-core@5.72.1':
+    resolution: {integrity: sha512-nOu0EEkZuJ0BZnYgeaEfo44+psq1jBO7/zp3KudixD4dvgOVerrhAhDEKsWx2N7MxB59mjO4r0ddP/VqWGPK+Q==}
+
+  '@tanstack/react-form@1.3.2':
+    resolution: {integrity: sha512-xjXQ9At7qDW7tDpiF1GXilXztLOa9hswNUGeNmkxvjSADd8wS7TduVOI/V7Lj6KKy60BOoYifJiSGePhlD5CmQ==}
+    peerDependencies:
+      '@tanstack/react-start': ^1.112.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      vinxi: ^0.5.0
+    peerDependenciesMeta:
+      '@tanstack/react-start':
+        optional: true
+      vinxi:
+        optional: true
+
+  '@tanstack/react-query@5.72.1':
+    resolution: {integrity: sha512-4UEMyRx54xj144D2nDvDIMiXSG5BrqyCJrmyNoGbymNS+VWODcBDFrmRk9p2fe12UGZ4JtKPTNuW2Jg0aisUgQ==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-store@0.7.0':
+    resolution: {integrity: sha512-S/Rq17HaGOk+tQHV/yrePMnG1xbsKZIl/VsNWnNXt4XW+tTY8dTlvpJH2ZQ3GRALsusG5K6Q3unAGJ2pd9W/Ng==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/store@0.7.0':
+    resolution: {integrity: sha512-CNIhdoUsmD2NolYuaIs8VfWM467RK6oIBAW4nPEKZhg1smZ+/CwtCdpURgp7nxSqOaV9oKkzdWD80+bC66F/Jg==}
+
+  '@trpc/client@11.0.4':
+    resolution: {integrity: sha512-2xIXqRNc8wH3zgcGp1yZ8P2ZL15BoFWq2RS8S3ldjvxsdJfnoYmcvCNzySw8nIrWbKiXl9prdw+bGIUOdG/omw==}
+    peerDependencies:
+      '@trpc/server': 11.0.4
+      typescript: '>=5.7.2'
+
+  '@trpc/react-query@11.0.4':
+    resolution: {integrity: sha512-rpzwKzE4r1bhuVvNZXI0eLaXZz7SkEAJ0VsJUo172gN3r8HqUoQjXcVKw+ZUre1RgxWbUf9jpILdfDOUTNZEvw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.67.1
+      '@trpc/client': 11.0.4
+      '@trpc/server': 11.0.4
+      react: '>=18.2.0'
+      react-dom: '>=18.2.0'
+      typescript: '>=5.7.2'
+
+  '@trpc/server@11.0.4':
+    resolution: {integrity: sha512-beDEGEw+slNiYxLUpZ8HKU1mnZBoP/VLMtrKh2ABKl7VC0PQV9XcDMVjB0GcSW15nTSiOnGDGyFDeudp4dH2qw==}
+    peerDependencies:
+      typescript: '>=5.7.2'
+
+  '@trpc/tanstack-react-query@11.0.4':
+    resolution: {integrity: sha512-8mCoJ0gfEaMfFDelnB1a6oWRjUP1uwJAOh3FHm6dGPtnycMpFj/yjg10/yE3Xgfoc3l4cL7WjugZRyrSi2XKig==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.67.1
+      '@trpc/client': 11.0.4
+      '@trpc/server': 11.0.4
+      react: '>=18.2.0'
+      react-dom: '>=18.2.0'
+      typescript: '>=5.7.2'
+
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
@@ -462,11 +868,26 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.20.7':
+    resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
+
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -486,6 +907,9 @@ packages:
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
 
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
+
   '@types/pg@8.11.11':
     resolution: {integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==}
 
@@ -495,11 +919,25 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/react-dom@19.1.1':
+    resolution: {integrity: sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w==}
+    peerDependencies:
+      '@types/react': ^19.0.0
+
+  '@types/react@19.1.0':
+    resolution: {integrity: sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==}
+
   '@types/send@0.17.4':
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
 
   '@types/serve-static@1.15.7':
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+
+  '@vitejs/plugin-react@4.3.4':
+    resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
   '@vitest/expect@3.0.8':
     resolution: {integrity: sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==}
@@ -530,6 +968,19 @@ packages:
   '@vitest/utils@3.0.8':
     resolution: {integrity: sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==}
 
+  '@web3-storage/multipart-parser@1.0.0':
+    resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
+
+  '@zxing/text-encoding@0.9.0':
+    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -542,6 +993,17 @@ packages:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -562,6 +1024,9 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
+  arktype@2.1.19:
+    resolution: {integrity: sha512-notORSuTSpfLV7rq0kYC4mTgIVlVR0xQuvtFxOaE9aKiXyON/kgoIBwZZcKeSSb4BebNcfJoGlxJicAUl/HMdw==}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -572,6 +1037,17 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  avvio@9.1.0:
+    resolution: {integrity: sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -581,6 +1057,14 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  browserslist@4.24.4:
+    resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -594,9 +1078,16 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001712:
+    resolution: {integrity: sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==}
 
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
@@ -628,6 +1119,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -635,6 +1129,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -646,6 +1144,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  data-uri-to-buffer@3.0.1:
+    resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
+    engines: {node: '>= 6'}
+
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
@@ -655,9 +1160,16 @@ packages:
       supports-color:
         optional: true
 
+  decode-formdata@0.9.0:
+    resolution: {integrity: sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -666,6 +1178,14 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.0.3:
+    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
+    engines: {node: '>=8'}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -684,6 +1204,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.134:
+    resolution: {integrity: sha512-zSwzrLg3jNP3bwsLqWHmS5z2nIOQ5ngMnfMZOWWtXnqqQkPVyOipxK98w+1beLw1TB+EImPNcG8wVP/cLVs2Og==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -693,6 +1216,10 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  enhanced-resolve@5.18.1:
+    resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
+    engines: {node: '>=10.13.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -718,6 +1245,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -728,6 +1259,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   expect-type@1.2.0:
     resolution: {integrity: sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==}
     engines: {node: '>=12.0.0'}
@@ -736,12 +1271,48 @@ packages:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stringify@6.0.1:
+    resolution: {integrity: sha512-s7SJE83QKBZwg54dIbD5rCtzOBVD43V1ReWXXYqBgwCwHLYAAT0RQc/FmrQglXqWPpz6omtryJQOau5jI4Nrvg==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-redact@3.5.0:
+    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
+    engines: {node: '>=6'}
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fastify-plugin@5.0.1:
+    resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
+
+  fastify@5.2.2:
+    resolution: {integrity: sha512-22T/PnhquWozuFXg3Ish4md5ipsF1Nx1mJ9ulLdZPXSk14WFj/wMlyNB/yll9sQOojKRgOIxT2inK3Xpjg5hyw==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
+
+  find-my-way@9.3.0:
+    resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
+    engines: {node: '>=20'}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -770,6 +1341,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -778,14 +1353,30 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.10.0:
+    resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
+
   glob@11.0.1:
     resolution: {integrity: sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==}
     engines: {node: 20 || >=22}
     hasBin: true
 
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -823,12 +1414,36 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.2.0:
+    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+    engines: {node: '>= 10'}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-generator-function@1.1.0:
+    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
+    engines: {node: '>= 0.4'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -837,8 +1452,98 @@ packages:
     resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
     engines: {node: 20 || >=22}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-schema-ref-resolver@2.0.1:
+    resolution: {integrity: sha512-HG0SIB9X4J8bwbxCbnd5FfPEbcXAJYTi1pBJeP/QPON+w8ovSME8iRG+ElHNxZNX2Qh6eYn1GdzJFS4cDFfx0Q==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
+
+  lightningcss-darwin-arm64@1.29.2:
+    resolution: {integrity: sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.29.2:
+    resolution: {integrity: sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.29.2:
+    resolution: {integrity: sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.29.2:
+    resolution: {integrity: sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.29.2:
+    resolution: {integrity: sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.29.2:
+    resolution: {integrity: sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.29.2:
+    resolution: {integrity: sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.29.2:
+    resolution: {integrity: sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.29.2:
+    resolution: {integrity: sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.29.2:
+    resolution: {integrity: sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.29.2:
+    resolution: {integrity: sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==}
+    engines: {node: '>= 12.0.0'}
 
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
@@ -846,6 +1551,9 @@ packages:
   lru-cache@11.0.2:
     resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -898,6 +1606,10 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mrmime@1.0.1:
+    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -910,12 +1622,19 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -995,6 +1714,20 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+
+  pino@9.6.0:
+    resolution: {integrity: sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==}
+    hasBin: true
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1034,6 +1767,9 @@ packages:
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1041,6 +1777,9 @@ packages:
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -1050,8 +1789,43 @@ packages:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
+  react-dom@19.1.0:
+    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+    peerDependencies:
+      react: ^19.1.0
+
+  react-refresh@0.14.2:
+    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.1.0:
+    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
+    engines: {node: '>=0.10.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
@@ -1070,8 +1844,34 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex2@5.0.0:
+    resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  secure-json-parse@3.0.2:
+    resolution: {integrity: sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
@@ -1080,6 +1880,13 @@ packages:
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1115,9 +1922,29 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+
+  sonner@2.0.3:
+    resolution: {integrity: sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -1132,6 +1959,9 @@ packages:
 
   std-env@3.8.1:
     resolution: {integrity: sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==}
+
+  stream-slice@0.1.2:
+    resolution: {integrity: sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1157,6 +1987,16 @@ packages:
     resolution: {integrity: sha512-5QeSO8hSrKghtcWEoPiO036fxH0Ii2wVQfFZSP0oqQhmjk8bOLhDFXr4JrvaFmPuEWUoq4znY3uSi8UzLKxGqw==}
     engines: {node: '>=14.18.0'}
 
+  tailwindcss@4.1.3:
+    resolution: {integrity: sha512-2Q+rw9vy1WFXu5cIxlvsabCwhU2qUwodGq03ODhLJ0jW4ek5BUtoCsnLB0qG+m8AHgEsSJcJGDSDe06FXlP74g==}
+
+  tapable@2.2.1:
+    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
+    engines: {node: '>=6'}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1175,6 +2015,10 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -1192,6 +2036,21 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  tsconfck@3.1.5:
+    resolution: {integrity: sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  tsx@4.19.3:
+    resolution: {integrity: sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   turbo-darwin-64@2.4.4:
     resolution: {integrity: sha512-5kPvRkLAfmWI0MH96D+/THnDMGXlFNmjeqNRj5grLKiry+M9pKj3pRuScddAXPdlxjO5Ptz06UNaOQrrYGTx1g==}
@@ -1212,6 +2071,9 @@ packages:
     resolution: {integrity: sha512-COXXwzRd3vslQIfJhXUklgEqlwq35uFUZ7hnN+AUyXx7hUOLIiD5NblL+ETrHnhY4TzWszrbwUMfe2BYWtaPQg==}
     cpu: [arm64]
     os: [linux]
+
+  turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
   turbo-windows-64@2.4.4:
     resolution: {integrity: sha512-PV9rYNouGz4Ff3fd6sIfQy5L7HT9a4fcZoEv8PKRavU9O75G7PoDtm8scpHU10QnK0QQNLbE9qNxOAeRvF0fJg==}
@@ -1239,9 +2101,30 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.21.2:
+    resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
+    engines: {node: '>=18.17'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -1255,8 +2138,56 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vite@6.2.2:
     resolution: {integrity: sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@6.2.5:
+    resolution: {integrity: sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -1323,6 +2254,17 @@ packages:
       jsdom:
         optional: true
 
+  web-encoding@1.1.5:
+    resolution: {integrity: sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  which-typed-array@1.1.19:
+    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+    engines: {node: '>= 0.4'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1348,6 +2290,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -1355,7 +2300,146 @@ packages:
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
+  zustand@5.0.3:
+    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@ark/schema@0.45.9':
+    dependencies:
+      '@ark/util': 0.45.9
+
+  '@ark/util@0.45.9': {}
+
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.26.8': {}
+
+  '@babel/core@7.26.10':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.27.0
+      '@babel/helper-compilation-targets': 7.27.0
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.10)
+      '@babel/helpers': 7.27.0
+      '@babel/parser': 7.27.0
+      '@babel/template': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@babel/types': 7.27.0
+      convert-source-map: 2.0.0
+      debug: 4.4.0
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.27.0':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.0':
+    dependencies:
+      '@babel/compat-data': 7.26.8
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.27.0
+      '@babel/types': 7.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.26.5': {}
+
+  '@babel/helper-string-parser@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
+
+  '@babel/helpers@7.27.0':
+    dependencies:
+      '@babel/template': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.27.0
+
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/template@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.27.0
+      '@babel/parser': 7.27.0
+      '@babel/template': 7.27.0
+      '@babel/types': 7.27.0
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.27.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -1471,6 +2555,44 @@ snapshots:
   '@esbuild/win32-x64@0.25.1':
     optional: true
 
+  '@fastify/ajv-compiler@4.0.2':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.0.6
+
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.0.2
+      fastify-plugin: 5.0.1
+
+  '@fastify/cors@11.0.1':
+    dependencies:
+      fastify-plugin: 5.0.1
+      toad-cache: 3.7.0
+
+  '@fastify/error@4.1.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.0.1
+
+  '@fastify/forwarded@3.0.0': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.0.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.0
+      ipaddr.js: 2.2.0
+
+  '@fastify/session@11.1.0':
+    dependencies:
+      fastify-plugin: 5.0.1
+      safe-stable-stringify: 2.5.0
+
   '@inversifyjs/common@1.5.0': {}
 
   '@inversifyjs/container@1.5.4(reflect-metadata@0.2.2)':
@@ -1505,14 +2627,81 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@jridgewell/gen-mapping@0.3.8':
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
+  '@jridgewell/set-array@1.2.1': {}
+
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@remix-run/node@2.16.5(typescript@5.8.2)':
+    dependencies:
+      '@remix-run/server-runtime': 2.16.5(typescript@5.8.2)
+      '@remix-run/web-fetch': 4.4.2
+      '@web3-storage/multipart-parser': 1.0.0
+      cookie-signature: 1.2.2
+      source-map-support: 0.5.21
+      stream-slice: 0.1.2
+      undici: 6.21.2
+    optionalDependencies:
+      typescript: 5.8.2
+
+  '@remix-run/router@1.23.0': {}
+
+  '@remix-run/server-runtime@2.16.5(typescript@5.8.2)':
+    dependencies:
+      '@remix-run/router': 1.23.0
+      '@types/cookie': 0.6.0
+      '@web3-storage/multipart-parser': 1.0.0
+      cookie: 0.7.2
+      set-cookie-parser: 2.7.1
+      source-map: 0.7.4
+      turbo-stream: 2.4.0
+    optionalDependencies:
+      typescript: 5.8.2
+
+  '@remix-run/web-blob@3.1.0':
+    dependencies:
+      '@remix-run/web-stream': 1.1.0
+      web-encoding: 1.1.5
+
+  '@remix-run/web-fetch@4.4.2':
+    dependencies:
+      '@remix-run/web-blob': 3.1.0
+      '@remix-run/web-file': 3.1.0
+      '@remix-run/web-form-data': 3.1.0
+      '@remix-run/web-stream': 1.1.0
+      '@web3-storage/multipart-parser': 1.0.0
+      abort-controller: 3.0.0
+      data-uri-to-buffer: 3.0.1
+      mrmime: 1.0.1
+
+  '@remix-run/web-file@3.1.0':
+    dependencies:
+      '@remix-run/web-blob': 3.1.0
+
+  '@remix-run/web-form-data@3.1.0':
+    dependencies:
+      web-encoding: 1.1.5
+
+  '@remix-run/web-stream@1.1.0':
+    dependencies:
+      web-streams-polyfill: 3.3.3
 
   '@rollup/rollup-android-arm-eabi@4.35.0':
     optional: true
@@ -1571,6 +2760,127 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.35.0':
     optional: true
 
+  '@standard-schema/spec@1.0.0': {}
+
+  '@tailwindcss/node@4.1.3':
+    dependencies:
+      enhanced-resolve: 5.18.1
+      jiti: 2.4.2
+      lightningcss: 1.29.2
+      tailwindcss: 4.1.3
+
+  '@tailwindcss/oxide-android-arm64@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.3
+      '@tailwindcss/oxide-darwin-arm64': 4.1.3
+      '@tailwindcss/oxide-darwin-x64': 4.1.3
+      '@tailwindcss/oxide-freebsd-x64': 4.1.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.3
+
+  '@tailwindcss/vite@4.1.3(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))':
+    dependencies:
+      '@tailwindcss/node': 4.1.3
+      '@tailwindcss/oxide': 4.1.3
+      tailwindcss: 4.1.3
+      vite: 6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+
+  '@tanstack/form-core@1.3.2':
+    dependencies:
+      '@tanstack/store': 0.7.0
+
+  '@tanstack/query-core@5.72.1': {}
+
+  '@tanstack/react-form@1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)':
+    dependencies:
+      '@remix-run/node': 2.16.5(typescript@5.8.2)
+      '@tanstack/form-core': 1.3.2
+      '@tanstack/react-store': 0.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      decode-formdata: 0.9.0
+      react: 19.1.0
+    transitivePeerDependencies:
+      - react-dom
+      - typescript
+
+  '@tanstack/react-query@5.72.1(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.72.1
+      react: 19.1.0
+
+  '@tanstack/react-store@0.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/store': 0.7.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      use-sync-external-store: 1.5.0(react@19.1.0)
+
+  '@tanstack/store@0.7.0': {}
+
+  '@trpc/client@11.0.4(@trpc/server@11.0.4(typescript@5.8.2))(typescript@5.8.2)':
+    dependencies:
+      '@trpc/server': 11.0.4(typescript@5.8.2)
+      typescript: 5.8.2
+
+  '@trpc/react-query@11.0.4(@tanstack/react-query@5.72.1(react@19.1.0))(@trpc/client@11.0.4(@trpc/server@11.0.4(typescript@5.8.2))(typescript@5.8.2))(@trpc/server@11.0.4(typescript@5.8.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)':
+    dependencies:
+      '@tanstack/react-query': 5.72.1(react@19.1.0)
+      '@trpc/client': 11.0.4(@trpc/server@11.0.4(typescript@5.8.2))(typescript@5.8.2)
+      '@trpc/server': 11.0.4(typescript@5.8.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      typescript: 5.8.2
+
+  '@trpc/server@11.0.4(typescript@5.8.2)':
+    dependencies:
+      typescript: 5.8.2
+
+  '@trpc/tanstack-react-query@11.0.4(@tanstack/react-query@5.72.1(react@19.1.0))(@trpc/client@11.0.4(@trpc/server@11.0.4(typescript@5.8.2))(typescript@5.8.2))(@trpc/server@11.0.4(typescript@5.8.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)':
+    dependencies:
+      '@tanstack/react-query': 5.72.1(react@19.1.0)
+      '@trpc/client': 11.0.4(@trpc/server@11.0.4(typescript@5.8.2))(typescript@5.8.2)
+      '@trpc/server': 11.0.4(typescript@5.8.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      typescript: 5.8.2
+
   '@tsconfig/node10@1.0.11': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -1579,20 +2889,43 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.7
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.27.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@types/babel__traverse@7.20.7':
+    dependencies:
+      '@babel/types': 7.27.0
+
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
+
+  '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.6': {}
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -1611,6 +2944,10 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
+  '@types/node@22.14.0':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/pg@8.11.11':
     dependencies:
       '@types/node': 22.13.10
@@ -1621,16 +2958,35 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-dom@19.1.1(@types/react@19.1.0)':
+    dependencies:
+      '@types/react': 19.1.0
+
+  '@types/react@19.1.0':
+    dependencies:
+      csstype: 3.1.3
+
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
       '@types/send': 0.17.4
+
+  '@vitejs/plugin-react@4.3.4(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@3.0.8':
     dependencies:
@@ -1639,13 +2995,21 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.8(vite@6.2.2(@types/node@22.13.10))':
+  '@vitest/mocker@3.0.8(vite@6.2.2(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))':
     dependencies:
       '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.2(@types/node@22.13.10)
+      vite: 6.2.2(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+
+  '@vitest/mocker@3.0.8(vite@6.2.2(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))':
+    dependencies:
+      '@vitest/spy': 3.0.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.2.2(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
 
   '@vitest/pretty-format@3.0.8':
     dependencies:
@@ -1672,6 +3036,17 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  '@web3-storage/multipart-parser@1.0.0': {}
+
+  '@zxing/text-encoding@0.9.0':
+    optional: true
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  abstract-logging@2.0.1: {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.1
@@ -1682,6 +3057,17 @@ snapshots:
       acorn: 8.14.1
 
   acorn@8.14.1: {}
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -1695,11 +3081,27 @@ snapshots:
 
   arg@4.1.3: {}
 
+  arktype@2.1.19:
+    dependencies:
+      '@ark/schema': 0.45.9
+      '@ark/util': 0.45.9
+
   asap@2.0.6: {}
 
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  avvio@9.1.0:
+    dependencies:
+      '@fastify/error': 4.1.0
+      fastq: 1.19.1
 
   balanced-match@1.0.2: {}
 
@@ -1721,6 +3123,15 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  browserslist@4.24.4:
+    dependencies:
+      caniuse-lite: 1.0.30001712
+      electron-to-chromium: 1.5.134
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.3(browserslist@4.24.4)
+
+  buffer-from@1.1.2: {}
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -1730,10 +3141,19 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  caniuse-lite@1.0.30001712: {}
 
   chai@5.2.0:
     dependencies:
@@ -1763,9 +3183,13 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.0.2: {}
 
   cookiejar@2.1.4: {}
 
@@ -1777,15 +3201,31 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.1.3: {}
+
+  data-uri-to-buffer@3.0.1: {}
+
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
 
+  decode-formdata@0.9.0: {}
+
   deep-eql@5.0.2: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.0.3: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -1804,11 +3244,18 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  electron-to-chromium@1.5.134: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  enhanced-resolve@5.18.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.1
 
   es-define-property@1.0.1: {}
 
@@ -1855,6 +3302,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.1
       '@esbuild/win32-x64': 0.25.1
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   estree-walker@3.0.3:
@@ -1862,6 +3311,8 @@ snapshots:
       '@types/estree': 1.0.6
 
   etag@1.8.1: {}
+
+  event-target-shim@5.0.1: {}
 
   expect-type@1.2.0: {}
 
@@ -1897,7 +3348,52 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-decode-uri-component@1.0.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stringify@6.0.1:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.0.6
+      json-schema-ref-resolver: 2.0.1
+      rfdc: 1.4.1
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
+  fast-redact@3.5.0: {}
+
   fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.0.6: {}
+
+  fastify-plugin@5.0.1: {}
+
+  fastify@5.2.2:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.2
+      '@fastify/error': 4.1.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.0.0
+      abstract-logging: 2.0.1
+      avvio: 9.1.0
+      fast-json-stringify: 6.0.1
+      find-my-way: 9.3.0
+      light-my-request: 6.6.0
+      pino: 9.6.0
+      process-warning: 4.0.1
+      rfdc: 1.4.1
+      secure-json-parse: 3.0.2
+      semver: 7.7.1
+      toad-cache: 3.7.0
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
 
   finalhandler@2.1.0:
     dependencies:
@@ -1909,6 +3405,16 @@ snapshots:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.3.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.0.0
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
 
   foreground-child@3.3.1:
     dependencies:
@@ -1937,6 +3443,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -1955,6 +3463,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-tsconfig@4.10.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob@11.0.1:
     dependencies:
       foreground-child: 3.3.1
@@ -1964,7 +3476,17 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
+  globals@11.12.0: {}
+
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -2001,9 +3523,36 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.2.0: {}
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
+  is-generator-function@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-promise@4.0.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.19
 
   isexe@2.0.0: {}
 
@@ -2011,11 +3560,80 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 8.0.2
 
+  jiti@2.4.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json-schema-ref-resolver@2.0.1:
+    dependencies:
+      dequal: 2.0.3
+
+  json-schema-traverse@1.0.0: {}
+
+  json5@2.2.3: {}
+
   jsonc-parser@3.3.1: {}
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.0.2
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.1
+
+  lightningcss-darwin-arm64@1.29.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.29.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.29.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.29.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.29.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.29.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.29.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.29.2:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.29.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.29.2:
+    optional: true
+
+  lightningcss@1.29.2:
+    dependencies:
+      detect-libc: 2.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.29.2
+      lightningcss-darwin-x64: 1.29.2
+      lightningcss-freebsd-x64: 1.29.2
+      lightningcss-linux-arm-gnueabihf: 1.29.2
+      lightningcss-linux-arm64-gnu: 1.29.2
+      lightningcss-linux-arm64-musl: 1.29.2
+      lightningcss-linux-x64-gnu: 1.29.2
+      lightningcss-linux-x64-musl: 1.29.2
+      lightningcss-win32-arm64-msvc: 1.29.2
+      lightningcss-win32-x64-msvc: 1.29.2
 
   loupe@3.1.3: {}
 
   lru-cache@11.0.2: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.17:
     dependencies:
@@ -2051,15 +3669,21 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mrmime@1.0.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.9: {}
 
   negotiator@1.0.0: {}
 
+  node-releases@2.0.19: {}
+
   object-inspect@1.13.4: {}
 
   obuf@1.1.2: {}
+
+  on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -2135,6 +3759,28 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.0.0: {}
+
+  pino@9.6.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 4.0.1
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.3:
     dependencies:
       nanoid: 3.3.9
@@ -2163,6 +3809,8 @@ snapshots:
 
   postgres-range@1.1.4: {}
 
+  process-warning@4.0.1: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -2171,6 +3819,8 @@ snapshots:
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
+
+  quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
 
@@ -2181,7 +3831,28 @@ snapshots:
       iconv-lite: 0.6.3
       unpipe: 1.0.0
 
+  react-dom@19.1.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.26.0
+
+  react-refresh@0.14.2: {}
+
+  react@19.1.0: {}
+
+  real-require@0.2.0: {}
+
   reflect-metadata@0.2.2: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  ret@0.5.0: {}
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rimraf@6.0.1:
     dependencies:
@@ -2225,7 +3896,27 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  safe-regex2@5.0.0:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
+
+  scheduler@0.26.0: {}
+
+  secure-json-parse@3.0.2: {}
+
+  semver@6.3.1: {}
+
+  semver@7.7.1: {}
 
   send@1.2.0:
     dependencies:
@@ -2251,6 +3942,17 @@ snapshots:
       send: 1.2.0
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   setprototypeof@1.2.0: {}
 
@@ -2292,7 +3994,25 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  sonner@2.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  source-map@0.7.4: {}
 
   split2@4.2.0: {}
 
@@ -2301,6 +4021,8 @@ snapshots:
   statuses@2.0.1: {}
 
   std-env@3.8.1: {}
+
+  stream-slice@0.1.2: {}
 
   string-width@4.2.3:
     dependencies:
@@ -2343,6 +4065,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  tailwindcss@4.1.3: {}
+
+  tapable@2.2.1: {}
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -2352,6 +4082,8 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@3.0.2: {}
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 
@@ -2373,6 +4105,17 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  tsconfck@3.1.5(typescript@5.8.2):
+    optionalDependencies:
+      typescript: 5.8.2
+
+  tsx@4.19.3:
+    dependencies:
+      esbuild: 0.25.1
+      get-tsconfig: 4.10.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.4.4:
     optional: true
 
@@ -2384,6 +4127,8 @@ snapshots:
 
   turbo-linux-arm64@2.4.4:
     optional: true
+
+  turbo-stream@2.4.0: {}
 
   turbo-windows-64@2.4.4:
     optional: true
@@ -2410,19 +4155,41 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  undici-types@6.21.0: {}
+
+  undici@6.21.2: {}
+
   unpipe@1.0.0: {}
+
+  update-browserslist-db@1.1.3(browserslist@4.24.4):
+    dependencies:
+      browserslist: 4.24.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.0
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.19
 
   v8-compile-cache-lib@3.0.1: {}
 
   vary@1.1.2: {}
 
-  vite-node@3.0.8(@types/node@22.13.10):
+  vite-node@3.0.8(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.2(@types/node@22.13.10)
+      vite: 6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2437,7 +4204,39 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.2(@types/node@22.13.10):
+  vite-node@3.0.8(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)):
+    dependencies:
+      debug: 4.4.0
+      globrex: 0.1.2
+      tsconfck: 3.1.5(typescript@5.8.2)
+    optionalDependencies:
+      vite: 6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite@6.2.2(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -2445,11 +4244,50 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.10
       fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.29.2
+      tsx: 4.19.3
 
-  vitest@3.0.8(@types/node@22.13.10):
+  vite@6.2.2(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3):
+    dependencies:
+      esbuild: 0.25.1
+      postcss: 8.5.3
+      rollup: 4.35.0
+    optionalDependencies:
+      '@types/node': 22.14.0
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.29.2
+      tsx: 4.19.3
+
+  vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3):
+    dependencies:
+      esbuild: 0.25.1
+      postcss: 8.5.3
+      rollup: 4.35.0
+    optionalDependencies:
+      '@types/node': 22.13.10
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.29.2
+      tsx: 4.19.3
+
+  vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3):
+    dependencies:
+      esbuild: 0.25.1
+      postcss: 8.5.3
+      rollup: 4.35.0
+    optionalDependencies:
+      '@types/node': 22.14.0
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.29.2
+      tsx: 4.19.3
+
+  vitest@3.0.8(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(vite@6.2.2(@types/node@22.13.10))
+      '@vitest/mocker': 3.0.8(vite@6.2.2(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
@@ -2465,8 +4303,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.2(@types/node@22.13.10)
-      vite-node: 3.0.8(@types/node@22.13.10)
+      vite: 6.2.2(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+      vite-node: 3.0.8(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.10
@@ -2483,6 +4321,62 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@3.0.8(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3):
+    dependencies:
+      '@vitest/expect': 3.0.8
+      '@vitest/mocker': 3.0.8(vite@6.2.2(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))
+      '@vitest/pretty-format': 3.0.8
+      '@vitest/runner': 3.0.8
+      '@vitest/snapshot': 3.0.8
+      '@vitest/spy': 3.0.8
+      '@vitest/utils': 3.0.8
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.1
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.2.2(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+      vite-node: 3.0.8(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.14.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  web-encoding@1.1.5:
+    dependencies:
+      util: 0.12.5
+    optionalDependencies:
+      '@zxing/text-encoding': 0.9.0
+
+  web-streams-polyfill@3.3.3: {}
+
+  which-typed-array@1.1.19:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:
@@ -2509,6 +4403,14 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  yallist@3.1.1: {}
+
   yn@3.1.1: {}
 
   zod@3.24.2: {}
+
+  zustand@5.0.3(@types/react@19.1.0)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
+    optionalDependencies:
+      '@types/react': 19.1.0
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)

--- a/recipes/react-trpc-fastify/config.jsonc
+++ b/recipes/react-trpc-fastify/config.jsonc
@@ -1,0 +1,6 @@
+{
+  "server": {
+    "port": 3001,
+    "enableLogging": true
+  }
+}

--- a/recipes/react-trpc-fastify/package.json
+++ b/recipes/react-trpc-fastify/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@typewirets/react-trpc-fastify",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start:server": "tsx watch ./src/server-main.ts",
+    "start:client": "vite",
+    "start": "pnpm --filter '@typewirets/react-trpc-fastify' --parallel '/^start:.*/'",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "author": "Rex Kim",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typewirets/typewirets.git",
+    "directory": "recipes/react-trpc-fastify"
+  },
+  "bugs": {
+    "url": "https://github.com/typewirets/typewirets/issues"
+  },
+  "dependencies": {
+    "@fastify/cookie": "^11.0.2",
+    "@fastify/cors": "^11.0.1",
+    "@fastify/session": "^11.1.0",
+    "@tanstack/react-form": "^1.3.2",
+    "@tanstack/react-query": "^5.72.1",
+    "@trpc/client": "^11.0.4",
+    "@trpc/react-query": "^11.0.4",
+    "@trpc/server": "^11.0.4",
+    "@trpc/tanstack-react-query": "^11.0.4",
+    "@typewirets/core": "workspace:*",
+    "arktype": "^2.1.19",
+    "fastify": "^5.2.2",
+    "jsonc-parser": "^3.3.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "sonner": "^2.0.3",
+    "tailwindcss": "^4.1.3",
+    "zod": "^3.24.2",
+    "zustand": "^5.0.3"
+  },
+  "devDependencies": {
+    "@standard-schema/spec": "^1.0.0",
+    "@tailwindcss/vite": "^4.1.3",
+    "@types/node": "^22.14.0",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "@typewirets/typescript-config": "workspace:*",
+    "@vitejs/plugin-react": "^4.3.4",
+    "tsx": "^4.19.3",
+    "typescript": "^5.3.3",
+    "vite": "^6.2.5",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.8"
+  }
+}

--- a/recipes/react-trpc-fastify/src/BrowserApp.tsx
+++ b/recipes/react-trpc-fastify/src/BrowserApp.tsx
@@ -1,0 +1,85 @@
+import type {
+  ResolutionContext,
+  TypeWire,
+  TypeSymbol,
+  AnyTypeWire,
+} from "@typewirets/core";
+import { ContainerContext } from "./hooks/ContainerContext";
+import { Suspense } from "react";
+import { TRPCProvider } from "./tier120/trpc.client";
+import { TRPCClientWire } from "./tier120/trpc.client.wire";
+import { QueryClientWire } from "./tier120/react-query.client.wire";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { useWire } from "./hooks/useWire";
+import { ClientScreen } from "./ClientScreen";
+import { Toaster } from "sonner";
+
+export function Providers() {
+  const trpcClient = useWire(TRPCClientWire);
+  const queryClient = useWire(QueryClientWire);
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+        <ClientScreen />
+      </TRPCProvider>
+    </QueryClientProvider>
+  );
+}
+
+export class ReactResolutionContext {
+  readonly #resolutionContext: ResolutionContext;
+  readonly #resolutions: Map<symbol, Promise<unknown>> = new Map();
+  readonly #resolutionErrors: Map<symbol, unknown> = new Map();
+
+  constructor(resolutionContext: ResolutionContext) {
+    this.#resolutionContext = resolutionContext;
+  }
+
+  getSync<T>(typeSymbol: TypeSymbol<T>): T {
+    if (this.#resolutionErrors.has(typeSymbol.symbol)) {
+      throw this.#resolutionErrors.get(typeSymbol.symbol);
+    }
+    return this.#resolutionContext.getSync(typeSymbol);
+  }
+
+  async get<T>(typeSymbol: TypeSymbol<T>): Promise<T> {
+    if (this.#resolutionErrors.has(typeSymbol.symbol)) {
+      throw this.#resolutionErrors.get(typeSymbol.symbol);
+    }
+
+    const promise = this.#resolutions.get(typeSymbol.symbol) as Promise<T>;
+    if (promise) {
+      return promise;
+    }
+
+    const newResolution = this.#resolutionContext.get(typeSymbol);
+    this.#resolutions.set(typeSymbol.symbol, newResolution);
+    return newResolution
+      .catch((err) => {
+        this.#resolutionErrors.set(typeSymbol.symbol, err);
+        throw err;
+      })
+      .finally(() => {
+        console.log("resolved");
+        this.#resolutions.delete(typeSymbol.symbol);
+      });
+  }
+}
+
+export function BrowserApp(props: {
+  container: ResolutionContext;
+}) {
+  const { container } = props;
+  const resolutionContext =
+    container instanceof ReactResolutionContext
+      ? container
+      : new ReactResolutionContext(container);
+  return (
+    <ContainerContext value={resolutionContext}>
+      <Suspense fallback={<div>loading</div>}>
+        <Providers />
+        <Toaster />
+      </Suspense>
+    </ContainerContext>
+  );
+}

--- a/recipes/react-trpc-fastify/src/BrowserApp.tsx
+++ b/recipes/react-trpc-fastify/src/BrowserApp.tsx
@@ -1,9 +1,4 @@
-import type {
-  ResolutionContext,
-  TypeWire,
-  TypeSymbol,
-  AnyTypeWire,
-} from "@typewirets/core";
+import type { ResolutionContext, TypeSymbol } from "@typewirets/core";
 import { ContainerContext } from "./hooks/ContainerContext";
 import { Suspense } from "react";
 import { TRPCProvider } from "./tier120/trpc.client";

--- a/recipes/react-trpc-fastify/src/ClientScreen.tsx
+++ b/recipes/react-trpc-fastify/src/ClientScreen.tsx
@@ -1,0 +1,19 @@
+import { useTRPC } from "./tier120/trpc.client";
+import { useQuery } from "@tanstack/react-query";
+import { LoginForm } from "./components/ui/LoginForm";
+import { UserScreen } from "./UserScreen";
+
+export function ClientScreen() {
+  const trpc = useTRPC();
+  const { isLoading, data, refetch } = useQuery(trpc.users.me.queryOptions());
+
+  if (isLoading) {
+    return;
+  }
+
+  if (!data?.authenticated) {
+    return <LoginForm onLoginChange={() => refetch()} />;
+  }
+
+  return <UserScreen onLoginChange={() => refetch()} />;
+}

--- a/recipes/react-trpc-fastify/src/UserScreen.tsx
+++ b/recipes/react-trpc-fastify/src/UserScreen.tsx
@@ -1,0 +1,167 @@
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { useTRPC } from "./tier120/trpc.client";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useWire } from "./hooks/useWire";
+import { AchievementStoreWire } from "./tier50/achivement/achievement.store";
+
+export function UserScreen(props: {
+  onLoginChange(): void;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const useAchivementStore = useWire(AchievementStoreWire);
+  const trackAction = useAchivementStore((state) => state.trackAction);
+  const [newUser, setNewUser] = useState({ name: "", age: "" });
+
+  const {
+    data: users = [],
+    isLoading,
+    refetch,
+  } = useQuery(trpc.users.getAll.queryOptions());
+
+  const addUser = useMutation(
+    trpc.users.save.mutationOptions({
+      onSuccess: async () => {
+        // Reset form
+        setNewUser({ name: "", age: "" });
+        trackAction("user-added");
+        refetch();
+      },
+    }),
+  );
+
+  const removeUser = useMutation(
+    trpc.users.delete.mutationOptions({
+      onSuccess: async () => {
+        trackAction("user-removed");
+        refetch();
+      },
+    }),
+  );
+
+  const logout = useMutation(
+    trpc.users.logout.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["users", "me"] });
+        props.onLoginChange();
+      },
+    }),
+  );
+
+  const handleAddUser = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newUser.name && newUser.age) {
+      const age = Number.parseInt(newUser.age, 10);
+      if (!Number.isNaN(age)) {
+        addUser.mutate({ id: age.toString(), name: newUser.name, age });
+      }
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+        <button
+          type="button"
+          onClick={() => logout.mutate()}
+          disabled={logout.isPending}
+          className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+        >
+          {logout.isPending ? "Logging out..." : "Logout"}
+        </button>
+      </div>
+
+      <div className="bg-white shadow-md rounded-lg overflow-hidden">
+        <form onSubmit={handleAddUser} className="p-4 border-b border-gray-200">
+          <div className="flex gap-4 items-end">
+            <div className="flex-1">
+              <label
+                htmlFor="name"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Name
+              </label>
+              <input
+                type="text"
+                id="name"
+                value={newUser.name}
+                onChange={(e) =>
+                  setNewUser((prev) => ({ ...prev, name: e.target.value }))
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="Enter name"
+              />
+            </div>
+            <div className="flex-1">
+              <label
+                htmlFor="age"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Age (ID)
+              </label>
+              <input
+                type="number"
+                id="age"
+                value={newUser.age}
+                onChange={(e) =>
+                  setNewUser((prev) => ({ ...prev, age: e.target.value }))
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="Enter age"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={addUser.isPending || !newUser.name || !newUser.age}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {addUser.isPending ? "Adding..." : "Add User"}
+            </button>
+          </div>
+        </form>
+
+        {isLoading ? (
+          <div className="p-4 text-center text-gray-500">Loading users...</div>
+        ) : (
+          <ul className="divide-y divide-gray-200">
+            {users.map((user) => (
+              <li
+                key={user.id}
+                className="p-4 hover:bg-gray-50 transition-colors duration-150"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-lg font-medium text-gray-900">
+                      {user.name}
+                    </h3>
+                    <p className="text-sm text-gray-500">Age: {user.age}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeUser.mutate(user.id)}
+                    disabled={removeUser.isPending}
+                    className="px-3 py-1 text-sm text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {removeUser.isPending ? "Removing..." : "Remove"}
+                  </button>
+                </div>
+                {addUser.isPending && addUser.variables?.name === user.name && (
+                  <div className="mt-2 text-sm text-blue-600">
+                    Adding user...
+                  </div>
+                )}
+                {removeUser.isPending && removeUser.variables === user.id && (
+                  <div className="mt-2 text-sm text-red-600">
+                    Removing user...
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/recipes/react-trpc-fastify/src/client-main.tsx
+++ b/recipes/react-trpc-fastify/src/client-main.tsx
@@ -1,0 +1,34 @@
+import { TypeWireContainer, typeWireGroupOf } from "@typewirets/core";
+import ReactDOM from "react-dom/client";
+import { BrowserApp } from "./BrowserApp";
+import { TrpcWire } from "./tier10/trpc.wire";
+import { TRPCClientWire } from "./tier120/trpc.client.wire";
+import { QueryClientWire } from "./tier120/react-query.client.wire";
+import { ToasterWire } from "./tier50/toaster/toaster.wire";
+import { AchievementStoreWire } from "./tier50/achivement/achievement.store";
+
+async function main() {
+  const rootId = "root";
+  const rootEl = document.querySelector(`#${rootId}`);
+  if (!rootEl) {
+    throw Error(`Element #${rootId} not found`);
+  }
+  const container = new TypeWireContainer();
+  const wireGroup = typeWireGroupOf([
+    TrpcWire,
+    TRPCClientWire,
+    QueryClientWire,
+    ToasterWire,
+    AchievementStoreWire,
+  ]);
+
+  await wireGroup.apply(container);
+  const root = ReactDOM.createRoot(rootEl);
+  root.render(<BrowserApp container={container} />);
+}
+
+main()
+  .then(() => {
+    console.log("main");
+  })
+  .catch(console.error);

--- a/recipes/react-trpc-fastify/src/components/ui/LoginForm.tsx
+++ b/recipes/react-trpc-fastify/src/components/ui/LoginForm.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "@tanstack/react-form";
+import { useTRPC } from "@typewirets/react-fastify/tier120/trpc.client";
+
+export function LoginForm(props: {
+  onLoginChange(): void;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [error, setError] = React.useState<string | null>(null);
+
+  const login = useMutation(
+    trpc.users.login.mutationOptions({
+      onSuccess: (data) => {
+        if (data) {
+          queryClient.invalidateQueries({ queryKey: ["users", "me"] });
+          props.onLoginChange();
+        }
+      },
+    }),
+  );
+
+  const form = useForm({
+    defaultValues: {
+      name: "",
+      password: "",
+    },
+    onSubmit: async ({ value }) => {
+      await login.mutateAsync({ id: value.name, password: value.password });
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        form.handleSubmit();
+      }}
+      className="space-y-4 w-full max-w-md mx-auto p-6 bg-white rounded-lg shadow-md"
+    >
+      <div className="space-y-2">
+        <form.Field name="name">
+          {(field) => (
+            <>
+              <label
+                htmlFor={field.name}
+                className="block text-sm font-medium text-gray-700"
+              >
+                Name
+              </label>
+              <input
+                id={field.name}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors && (
+                <p className="text-sm text-red-500">
+                  {field.state.meta.errors}
+                </p>
+              )}
+            </>
+          )}
+        </form.Field>
+      </div>
+
+      <div className="space-y-2">
+        <form.Field name="password">
+          {(field) => (
+            <>
+              <label
+                htmlFor={field.name}
+                className="block text-sm font-medium text-gray-700"
+              >
+                Password
+              </label>
+              <input
+                id={field.name}
+                type="password"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors && (
+                <p className="text-sm text-red-500">
+                  {field.state.meta.errors}
+                </p>
+              )}
+            </>
+          )}
+        </form.Field>
+      </div>
+
+      {error && <div className="text-sm text-red-500">{error}</div>}
+
+      <form.Subscribe
+        selector={(state) => [state.canSubmit, state.isSubmitting]}
+      >
+        {([canSubmit, isSubmitting]) => (
+          <button
+            type="submit"
+            disabled={!canSubmit || isSubmitting}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? "Logging in..." : "Login"}
+          </button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}

--- a/recipes/react-trpc-fastify/src/components/ui/LoginForm.tsx
+++ b/recipes/react-trpc-fastify/src/components/ui/LoginForm.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "@tanstack/react-form";
 import { useTRPC } from "@typewirets/react-fastify/tier120/trpc.client";
@@ -8,7 +7,6 @@ export function LoginForm(props: {
 }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const [error, setError] = React.useState<string | null>(null);
 
   const login = useMutation(
     trpc.users.login.mutationOptions({
@@ -94,8 +92,6 @@ export function LoginForm(props: {
           )}
         </form.Field>
       </div>
-
-      {error && <div className="text-sm text-red-500">{error}</div>}
 
       <form.Subscribe
         selector={(state) => [state.canSubmit, state.isSubmitting]}

--- a/recipes/react-trpc-fastify/src/config/tier0/config-loader.wire.ts
+++ b/recipes/react-trpc-fastify/src/config/tier0/config-loader.wire.ts
@@ -1,0 +1,9 @@
+import { typeWireOf } from "@typewirets/core";
+
+export interface ConfigLoader {
+  load(): Promise<Record<string, unknown>>;
+}
+
+export const ConfigLoaderWire = typeWireOf<ConfigLoader>({
+  token: "ConfigLoader",
+});

--- a/recipes/react-trpc-fastify/src/config/tier0/jsonc-config-loader.ts
+++ b/recipes/react-trpc-fastify/src/config/tier0/jsonc-config-loader.ts
@@ -1,0 +1,19 @@
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import * as JSONC from "jsonc-parser";
+
+export type ConfigLoaderOpts = {
+  rootDir: string;
+  configName: string;
+};
+
+export async function loadJsoncConfig(
+  opts?: ConfigLoaderOpts,
+): Promise<Record<string, unknown>> {
+  const rootDir = opts?.rootDir ?? process.cwd();
+  const configName = opts?.configName ?? "config.jsonc";
+  const configPath = path.join(rootDir, configName);
+  const configContent = await fs.readFile(configPath, "utf-8");
+  const parsed = JSONC.parse(configContent);
+  return parsed;
+}

--- a/recipes/react-trpc-fastify/src/config/tier0/jsonc-config-loader.wire.ts
+++ b/recipes/react-trpc-fastify/src/config/tier0/jsonc-config-loader.wire.ts
@@ -1,0 +1,13 @@
+import { typeWireOf } from "@typewirets/core";
+import { loadJsoncConfig } from "./jsonc-config-loader";
+
+export const JsonsConfigLoaderWire = typeWireOf({
+  token: "JsoncConfigLoader",
+  creator() {
+    return {
+      async load() {
+        return loadJsoncConfig();
+      },
+    };
+  },
+});

--- a/recipes/react-trpc-fastify/src/config/tier0/server-config.ts
+++ b/recipes/react-trpc-fastify/src/config/tier0/server-config.ts
@@ -1,0 +1,8 @@
+import { type } from "arktype";
+
+export const ServerConfigType = type({
+  port: "number?",
+  enableLogging: "boolean?",
+});
+
+export type ServerConfigRecord = typeof ServerConfigType.infer;

--- a/recipes/react-trpc-fastify/src/config/tier1/config-service.ts
+++ b/recipes/react-trpc-fastify/src/config/tier1/config-service.ts
@@ -1,0 +1,76 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+export class ConfigService {
+  constructor(private readonly record: Record<string, unknown>) {}
+
+  // biome-ignore lint/suspicious/noExplicitAny: parsed config must get resolved at runtime.
+  private getAnyValue(keys: string[]): any | undefined {
+    // biome-ignore lint/suspicious/noExplicitAny: parsed config must get resolved at runtime.
+    let cur: any | undefined = this.record;
+    const keySize = keys.length;
+    for (let idx = 0; idx < keySize; idx++) {
+      if (Array.isArray(cur)) {
+        if (idx < keySize - 1) {
+          return;
+        }
+      }
+
+      if (typeof cur === "object") {
+        const key = keys[idx] as string;
+        cur = cur[key];
+      }
+    }
+
+    return cur;
+  }
+
+  #getParsedResult<T>(
+    key: string,
+    schema: StandardSchemaV1<unknown, T>,
+  ): StandardSchemaV1.Result<T> | Promise<StandardSchemaV1.Result<T>> {
+    if (!key) {
+      throw Error("empty key is not allowed");
+    }
+
+    const rawValue = this.getAnyValue(key.split("."));
+    return schema["~standard"].validate(rawValue);
+  }
+
+  #throwIfFailed<T>(
+    result: StandardSchemaV1.Result<T>,
+  ): asserts result is StandardSchemaV1.SuccessResult<T> {
+    if ("issues" in result) {
+      throw new Error(
+        `Validation failed: ${result.issues?.map((issue) => issue.message).join(", ")}`,
+      );
+    }
+  }
+
+  get<T>(key: string, schema: StandardSchemaV1<unknown, T>): T {
+    const result = this.#getParsedResult(key, schema);
+    if ("then" in result) {
+      // this is promise
+      throw new Error("use getAsync");
+    }
+
+    this.#throwIfFailed(result);
+    return result.value;
+  }
+
+  async getAsync<T>(
+    key: string,
+    schema: StandardSchemaV1<unknown, T>,
+  ): Promise<T> {
+    const result = await this.#getParsedResult(key, schema);
+    this.#throwIfFailed(result);
+    return result.value;
+  }
+
+  getSlice<T>(key: string): T[] {
+    if (!key) {
+      throw Error("empty key is not allowed");
+    }
+
+    return this.getAnyValue(key.split(".")) as T[];
+  }
+}

--- a/recipes/react-trpc-fastify/src/config/tier1/config-service.wire.ts
+++ b/recipes/react-trpc-fastify/src/config/tier1/config-service.wire.ts
@@ -1,0 +1,14 @@
+import { typeWireOf } from "@typewirets/core";
+import { ConfigLoaderWire } from "@typewirets/react-fastify/config/tier0/config-loader.wire";
+import { ConfigService } from "./config-service";
+
+export const ConfigServiceWire = typeWireOf({
+  token: "ConfigService",
+  imports: {
+    loader: ConfigLoaderWire,
+  },
+  async createWith({ loader }) {
+    const record = await loader.load();
+    return new ConfigService(record);
+  },
+});

--- a/recipes/react-trpc-fastify/src/fastify-app.wire.ts
+++ b/recipes/react-trpc-fastify/src/fastify-app.wire.ts
@@ -1,0 +1,20 @@
+import Fastify from "fastify";
+import { typeWireOf } from "@typewirets/core";
+import { ServerConfigType } from "@typewirets/react-fastify/config/tier0/server-config";
+import { ConfigServiceWire } from "@typewirets/react-fastify/config/tier1/config-service.wire";
+
+export const FastifyWire = typeWireOf({
+  token: "Fastify",
+  imports: {
+    configService: ConfigServiceWire,
+  },
+  async createWith({ configService }) {
+    const serverConfig = configService.get("server", ServerConfigType);
+
+    const fastify = Fastify({
+      logger: serverConfig.enableLogging ?? false,
+    });
+
+    return fastify;
+  },
+});

--- a/recipes/react-trpc-fastify/src/hooks/ContainerContext.tsx
+++ b/recipes/react-trpc-fastify/src/hooks/ContainerContext.tsx
@@ -1,0 +1,6 @@
+import { type ResolutionContext, TypeWireContainer } from "@typewirets/core";
+import { createContext } from "react";
+
+export const ContainerContext = createContext<ResolutionContext>(
+  new TypeWireContainer(),
+);

--- a/recipes/react-trpc-fastify/src/hooks/useContainer.ts
+++ b/recipes/react-trpc-fastify/src/hooks/useContainer.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { ContainerContext } from "./ContainerContext";
+
+export function useContainer() {
+  return useContext(ContainerContext);
+}

--- a/recipes/react-trpc-fastify/src/hooks/useWire.ts
+++ b/recipes/react-trpc-fastify/src/hooks/useWire.ts
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { type TypeWire, TypeWireError } from "@typewirets/core";
+import { useContainer } from "./useContainer";
+
+export function useWire<T>(typeWire: TypeWire<T>): T {
+  const container = useContainer();
+  const [value, setValue] = React.useState(() => {
+    try {
+      return typeWire.getInstanceSync(container);
+    } catch (err: unknown) {
+      if (err instanceof TypeWireError && err.reason === "AsyncOnlyBinding") {
+        return null;
+      }
+
+      throw err;
+    }
+  });
+
+  const promise = typeWire.getInstance(container);
+  React.useEffect(() => {
+    let mounted = false;
+
+    promise
+      .then((value) => {
+        if (mounted) {
+          setValue(() => value);
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [promise]);
+
+  if (value) {
+    return value;
+  }
+
+  throw promise;
+}

--- a/recipes/react-trpc-fastify/src/index.css
+++ b/recipes/react-trpc-fastify/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/recipes/react-trpc-fastify/src/index.html
+++ b/recipes/react-trpc-fastify/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="/index.css" rel="stylesheet">
+  <title>React App</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/client-main.tsx"></script>
+</body>
+</html>

--- a/recipes/react-trpc-fastify/src/server-main.ts
+++ b/recipes/react-trpc-fastify/src/server-main.ts
@@ -1,0 +1,56 @@
+import { type ResolutionContext, TypeWireContainer } from "@typewirets/core";
+import {
+  fastifyTRPCPlugin,
+  type FastifyTRPCPluginOptions,
+} from "@trpc/server/adapters/fastify";
+import cookie from "@fastify/cookie";
+import session from "@fastify/session";
+
+import { FastifyWire } from "./fastify-app.wire";
+import { SeverMainWires } from "./server-main.wires";
+import { ConfigServiceWire } from "./config/tier1/config-service.wire";
+import { ServerConfigType } from "./config/tier0/server-config";
+import { ConfigLoaderWire } from "./config/tier0/config-loader.wire";
+import { JsonsConfigLoaderWire } from "./config/tier0/jsonc-config-loader.wire";
+import { type AppRouter, AppRouterWire } from "./tier110/app-router.wire";
+import { createContext } from "./tier100/routers/router.context";
+
+async function main() {
+  const container = new TypeWireContainer();
+  const mainWires = SeverMainWires.withExtraWires([
+    JsonsConfigLoaderWire,
+    ConfigLoaderWire.withCreator(async (ctx: ResolutionContext) => {
+      return await JsonsConfigLoaderWire.getInstance(ctx);
+    }),
+  ]);
+
+  await mainWires.apply(container);
+  const server = await FastifyWire.getInstance(container);
+  const configService = await ConfigServiceWire.getInstance(container);
+  const appRouter = await AppRouterWire.getInstance(container);
+
+  server.register(cookie);
+  server.register(session, {
+    secret: "example81728937120987318297312897312897392",
+    cookieName: "ses",
+  });
+
+  server.register(fastifyTRPCPlugin, {
+    prefix: "/trpc",
+    trpcOptions: {
+      router: appRouter,
+      createContext,
+      onError({ path, error }) {
+        // report to error monitoring
+        console.error(`Error in tRPC handler on path '${path}':`, error);
+      },
+    } satisfies FastifyTRPCPluginOptions<AppRouter>["trpcOptions"],
+  });
+
+  const serverConfig = configService.get("server", ServerConfigType);
+  const port = serverConfig.port ?? 300;
+
+  await server.listen({ port });
+}
+
+await main();

--- a/recipes/react-trpc-fastify/src/server-main.wires.ts
+++ b/recipes/react-trpc-fastify/src/server-main.wires.ts
@@ -1,0 +1,11 @@
+import { typeWireGroupOf } from "@typewirets/core";
+
+import { ConfigLoaderWire } from "@typewirets/react-fastify/config/tier0/config-loader.wire";
+import { FastifyWire } from "./fastify-app.wire";
+import { AppRouterWire } from "./tier110/app-router.wire";
+
+export const SeverMainWires = typeWireGroupOf([
+  ConfigLoaderWire,
+  FastifyWire,
+  AppRouterWire,
+]);

--- a/recipes/react-trpc-fastify/src/tier10/trpc.context.ts
+++ b/recipes/react-trpc-fastify/src/tier10/trpc.context.ts
@@ -1,0 +1,6 @@
+export interface Context {
+  isAuthenticated(): Promise<boolean>;
+  getCurrentUserId(): Promise<string | undefined>;
+  authenticate(userId: string): Promise<void>;
+  clearUser(): Promise<void>;
+}

--- a/recipes/react-trpc-fastify/src/tier10/trpc.ts
+++ b/recipes/react-trpc-fastify/src/tier10/trpc.ts
@@ -1,0 +1,8 @@
+import { initTRPC } from "@trpc/server";
+import type { Context } from "./trpc.context.ts";
+
+export function createTrpc() {
+  return initTRPC.context<Context>().create();
+}
+
+export type TRPC = ReturnType<typeof createTrpc>;

--- a/recipes/react-trpc-fastify/src/tier10/trpc.wire.ts
+++ b/recipes/react-trpc-fastify/src/tier10/trpc.wire.ts
@@ -1,0 +1,10 @@
+import { typeWireOf } from "@typewirets/core";
+import { createTrpc } from "./trpc";
+
+export const TrpcWire = typeWireOf({
+  token: "TRPC",
+  creator(_ctx) {
+    const trpc = createTrpc();
+    return trpc;
+  },
+});

--- a/recipes/react-trpc-fastify/src/tier100/routers/router.context.ts
+++ b/recipes/react-trpc-fastify/src/tier100/routers/router.context.ts
@@ -1,0 +1,37 @@
+import type { CreateFastifyContextOptions } from "@trpc/server/adapters/fastify";
+import type { Context } from "@typewirets/react-fastify/tier10/trpc.context";
+import type { FastifyRequest } from "fastify/types/request";
+
+export class FastifyTrpcContext implements Context {
+  constructor(readonly req: FastifyRequest) {}
+
+  async isAuthenticated(): Promise<boolean> {
+    //@ts-ignore
+    return this.req.session.authenticated ?? false;
+  }
+
+  async getCurrentUserId(): Promise<string | undefined> {
+    //@ts-ignore
+    return this.req.session.userId;
+  }
+
+  async authenticate(userId: string): Promise<void> {
+    //@ts-ignore
+    this.req.session.authenticated = true;
+    //@ts-ignore
+    this.req.session.userId = userId;
+    await this.req.session.save();
+  }
+
+  async clearUser(): Promise<void> {
+    //@ts-ignore
+    this.req.session.authenticated = false;
+    //@ts-ignore
+    this.req.session.userId = undefined;
+    await this.req.session.destroy();
+  }
+}
+
+export function createContext({ req }: CreateFastifyContextOptions) {
+  return new FastifyTrpcContext(req);
+}

--- a/recipes/react-trpc-fastify/src/tier100/routers/user.router.ts
+++ b/recipes/react-trpc-fastify/src/tier100/routers/user.router.ts
@@ -1,0 +1,113 @@
+import { TRPCError } from "@trpc/server";
+import type { TRPC } from "@typewirets/react-fastify/tier10/trpc";
+import type { UserStore } from "@typewirets/react-fastify/tier50/users/user.store";
+import { UserType } from "@typewirets/react-fastify/tier50/users/user.type";
+import { type } from "arktype";
+
+export type UserRouterOpt = {
+  trpc: TRPC;
+  userStore: UserStore;
+};
+
+export const ByIdInputType = type("string");
+
+export type ByIdInput = typeof ByIdInputType.infer;
+
+export const LoginInputType = type({
+  id: "string",
+  password: "string",
+});
+
+export function createUserRouter(opt: UserRouterOpt) {
+  const { trpc, userStore } = opt;
+
+  return trpc.router({
+    users: {
+      me: trpc.procedure.query(async (opts) => {
+        if (!(await opts.ctx.isAuthenticated())) {
+          return {
+            authenticated: false,
+          };
+        }
+
+        const userId = await opts.ctx.getCurrentUserId();
+        if (!userId) {
+          return {
+            authenticated: false,
+          };
+        }
+
+        const user = await userStore.getUserById(userId);
+        return {
+          authenticated: true,
+          user,
+        };
+      }),
+
+      byId: trpc.procedure.input(ByIdInputType).query(async (opt) => {
+        if (!(await opt.ctx.isAuthenticated())) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Must Login",
+          });
+        }
+        return userStore.getUserById(opt.input);
+      }),
+
+      login: trpc.procedure.input(LoginInputType).mutation(async (opt) => {
+        const { id } = opt.input;
+        const user = await userStore.getUserById(id);
+        if (user) {
+          await opt.ctx.authenticate(user.id);
+        }
+
+        return user;
+      }),
+
+      logout: trpc.procedure.mutation(async (opt) => {
+        if (await opt.ctx.isAuthenticated()) {
+          await opt.ctx.clearUser();
+          return { result: true };
+        }
+
+        return { result: false };
+      }),
+
+      save: trpc.procedure.input(UserType).mutation(async (opts) => {
+        if (!(await opts.ctx.isAuthenticated())) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Must Login",
+          });
+        }
+
+        const userToSave = opts.input;
+        await userStore.save(userToSave);
+        return userStore.getUserById(userToSave.id);
+      }),
+
+      delete: trpc.procedure.input(ByIdInputType).mutation(async (opt) => {
+        if (!(await opt.ctx.isAuthenticated())) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Must Login",
+          });
+        }
+
+        await userStore.delete(opt.input);
+      }),
+
+      getAll: trpc.procedure.query(async (opt) => {
+        if (!(await opt.ctx.isAuthenticated())) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Must Login",
+          });
+        }
+        return userStore.getAll();
+      }),
+    },
+  });
+}
+
+export type UserRouter = ReturnType<typeof createUserRouter>;

--- a/recipes/react-trpc-fastify/src/tier100/routers/user.router.wire.ts
+++ b/recipes/react-trpc-fastify/src/tier100/routers/user.router.wire.ts
@@ -1,0 +1,18 @@
+import { typeWireOf } from "@typewirets/core";
+import { createUserRouter } from "./user.router";
+import { TrpcWire } from "@typewirets/react-fastify/tier10/trpc.wire";
+import { UserStoreWire } from "@typewirets/react-fastify/tier50/users/user.store.wire";
+
+export const UserRouterWire = typeWireOf({
+  token: "UserRouter",
+  imports: {
+    trpc: TrpcWire,
+    userStore: UserStoreWire,
+  },
+  createWith({ trpc, userStore }) {
+    return createUserRouter({
+      trpc,
+      userStore,
+    });
+  },
+});

--- a/recipes/react-trpc-fastify/src/tier110/app-router.wire.ts
+++ b/recipes/react-trpc-fastify/src/tier110/app-router.wire.ts
@@ -1,0 +1,16 @@
+import { typeWireOf, type InferWireType } from "@typewirets/core";
+import { TrpcWire } from "@typewirets/react-fastify/tier10/trpc.wire";
+import { UserRouterWire } from "../tier100/routers/user.router.wire";
+
+export const AppRouterWire = typeWireOf({
+  token: "AppRouter",
+  imports: {
+    trpc: TrpcWire,
+    userRouter: UserRouterWire,
+  },
+  createWith({ trpc, userRouter }) {
+    return trpc.mergeRouters(userRouter);
+  },
+});
+
+export type AppRouter = InferWireType<typeof AppRouterWire>;

--- a/recipes/react-trpc-fastify/src/tier120/react-query.client.wire.ts
+++ b/recipes/react-trpc-fastify/src/tier120/react-query.client.wire.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { QueryClient } from "@tanstack/react-query";
+import { typeWireOf } from "@typewirets/core";
+
+export function createQueryClient(): QueryClient {
+  return new QueryClient();
+}
+
+export const QueryClientWire = typeWireOf({
+  token: "QueryClient",
+  creator() {
+    return createQueryClient();
+  },
+});

--- a/recipes/react-trpc-fastify/src/tier120/trpc.client.ts
+++ b/recipes/react-trpc-fastify/src/tier120/trpc.client.ts
@@ -1,0 +1,7 @@
+"use client";
+
+import type { AppRouter } from "@typewirets/react-fastify/tier110/app-router.wire";
+import { createTRPCContext } from "@trpc/tanstack-react-query";
+
+export const { TRPCProvider, useTRPC, useTRPCClient } =
+  createTRPCContext<AppRouter>();

--- a/recipes/react-trpc-fastify/src/tier120/trpc.client.wire.ts
+++ b/recipes/react-trpc-fastify/src/tier120/trpc.client.wire.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { typeWireOf } from "@typewirets/core";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import type { AppRouter } from "@typewirets/react-fastify/tier110/app-router.wire";
+
+function create() {
+  const client = createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: "/trpc",
+      }),
+    ],
+  });
+  return client;
+}
+
+export const TRPCClientWire = typeWireOf<ReturnType<typeof create>>({
+  token: "TRPCClient",
+  creator() {
+    const client = create();
+    return client;
+  },
+});

--- a/recipes/react-trpc-fastify/src/tier50/achivement/achievement.store.ts
+++ b/recipes/react-trpc-fastify/src/tier50/achivement/achievement.store.ts
@@ -1,0 +1,82 @@
+import { typeWireOf } from "@typewirets/core";
+import { create } from "zustand";
+import type { Achievement } from "./achievement.type";
+import { ToasterWire } from "../toaster/toaster.wire";
+import { TRPCClientWire } from "@typewirets/react-fastify/tier120/trpc.client.wire";
+
+interface AchievementState {
+  achievements: Achievement[];
+  trackAction(action: string): Promise<void>;
+}
+
+// stores/achievement.store.ts
+export const AchievementStoreWire = typeWireOf({
+  token: "AchievementStore",
+  imports: {
+    trpc: TRPCClientWire,
+    toaster: ToasterWire,
+  },
+  createWith({ toaster }) {
+    return create<AchievementState>()((set) => ({
+      achievements: [
+        {
+          title: "Penta Kill",
+          description: "Destoyed User more than 5",
+          action: "user-removed",
+          progress: 0,
+          total: 5,
+          completed: false,
+        },
+        {
+          title: "Monster Kill",
+          description: "Destoyed User more than 10",
+          action: "user-removed",
+          progress: 0,
+          total: 10,
+          completed: false,
+        },
+        {
+          title: "Life Creator",
+          description: "Created User more than 3",
+          action: "user-added",
+          progress: 0,
+          total: 3,
+          completed: false,
+        },
+      ],
+
+      // Track user actions
+      trackAction: async (action: string) => {
+        // Update local state optimistically
+        set((state) => {
+          const freshCompletions: Achievement[] = [];
+          const updatedAchievements = state.achievements.map((achievement) => {
+            if (achievement.action === action && !achievement.completed) {
+              const newProgress = achievement.progress + 1;
+              const newState = {
+                ...achievement,
+                progress: newProgress,
+                completed: newProgress >= achievement.total,
+              };
+
+              if (newState.completed) {
+                freshCompletions.push(newState);
+              }
+
+              return newState;
+            }
+            return achievement;
+          });
+
+          if (freshCompletions.length > 0) {
+            for (const item of freshCompletions) {
+              toaster.success(item.title);
+            }
+          }
+
+          return { achievements: updatedAchievements };
+        });
+      },
+    }));
+  },
+});

--- a/recipes/react-trpc-fastify/src/tier50/achivement/achievement.type.ts
+++ b/recipes/react-trpc-fastify/src/tier50/achivement/achievement.type.ts
@@ -1,0 +1,8 @@
+export type Achievement = {
+  title: string;
+  description: string;
+  action: string;
+  progress: number;
+  total: number;
+  completed: boolean;
+};

--- a/recipes/react-trpc-fastify/src/tier50/session/session-type.d.ts
+++ b/recipes/react-trpc-fastify/src/tier50/session/session-type.d.ts
@@ -1,0 +1,11 @@
+import "fastify";
+import type { Session } from "@fastify/session";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    session: Session & {
+      authenticated?: boolean;
+      userId?: string;
+    };
+  }
+}

--- a/recipes/react-trpc-fastify/src/tier50/toaster/toaster.service.ts
+++ b/recipes/react-trpc-fastify/src/tier50/toaster/toaster.service.ts
@@ -1,0 +1,45 @@
+export type ToastMessage = (() => React.ReactNode) | React.ReactNode;
+
+export interface ToastIcons {
+  success?: React.ReactNode;
+  info?: React.ReactNode;
+  warning?: React.ReactNode;
+  error?: React.ReactNode;
+  loading?: React.ReactNode;
+  close?: React.ReactNode;
+}
+
+export interface Action {
+  label: React.ReactNode;
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  actionButtonStyle?: React.CSSProperties;
+}
+
+export interface ToastOption {
+  icon?: React.ReactNode;
+  closeButton?: boolean;
+  dismissible?: boolean;
+  richColors?: boolean;
+  action?: Action | React.ReactNode;
+  cancel?: Action | React.ReactNode;
+}
+
+export interface ToasterService {
+  success: (
+    message: ToastMessage | React.ReactNode,
+    data?: ToastOption,
+  ) => string | number;
+  info: (
+    message: ToastMessage | React.ReactNode,
+    data?: ToastOption,
+  ) => string | number;
+  warning: (
+    message: ToastMessage | React.ReactNode,
+    data?: ToastOption,
+  ) => string | number;
+  error: (
+    message: ToastMessage | React.ReactNode,
+    data?: ToastOption,
+  ) => string | number;
+  dismiss: (id?: number | string) => string | number;
+}

--- a/recipes/react-trpc-fastify/src/tier50/toaster/toaster.wire.ts
+++ b/recipes/react-trpc-fastify/src/tier50/toaster/toaster.wire.ts
@@ -1,0 +1,10 @@
+import { typeWireOf } from "@typewirets/core";
+import { toast } from "sonner";
+import type { ToasterService } from "./toaster.service";
+
+export const ToasterWire = typeWireOf({
+  token: "Toaster",
+  creator(): ToasterService {
+    return toast satisfies ToasterService;
+  },
+});

--- a/recipes/react-trpc-fastify/src/tier50/users/user.store.ts
+++ b/recipes/react-trpc-fastify/src/tier50/users/user.store.ts
@@ -1,0 +1,8 @@
+import type { User } from "./user.type";
+
+export interface UserStore {
+  getUserById(id: string): Promise<User | undefined>;
+  getAll(): Promise<User[]>;
+  save(user: User): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/recipes/react-trpc-fastify/src/tier50/users/user.store.wire.ts
+++ b/recipes/react-trpc-fastify/src/tier50/users/user.store.wire.ts
@@ -1,0 +1,42 @@
+import { typeWireOf } from "@typewirets/core";
+import type { UserStore } from "./user.store";
+import type { User } from "./user.type";
+
+class InMemoryUserStore {
+  #users: Map<string, User> = new Map();
+
+  constructor() {
+    // init with default admin user
+    const userId = "admin";
+    this.#users.set(userId, {
+      id: userId,
+      name: "SuperAdmin",
+      // old thus wise
+      age: 9999999,
+    });
+  }
+
+  async getUserById(id: string): Promise<User | undefined> {
+    return this.#users.get(id);
+  }
+
+  async save(user: User): Promise<void> {
+    this.#users.set(user.id, user);
+  }
+
+  async getAll(): Promise<User[]> {
+    return Array.from(this.#users.values());
+  }
+
+  async delete(id: string): Promise<void> {
+    this.#users.delete(id);
+  }
+}
+
+export const UserStoreWire = typeWireOf({
+  token: "UserStore",
+  creator(_ctx) {
+    const userStore = new InMemoryUserStore();
+    return userStore satisfies UserStore;
+  },
+});

--- a/recipes/react-trpc-fastify/src/tier50/users/user.type.ts
+++ b/recipes/react-trpc-fastify/src/tier50/users/user.type.ts
@@ -1,0 +1,9 @@
+import { type } from "arktype";
+
+export const UserType = type({
+  id: "string",
+  name: "string",
+  age: "number",
+});
+
+export type User = typeof UserType.infer;

--- a/recipes/react-trpc-fastify/tsconfig.build.json
+++ b/recipes/react-trpc-fastify/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "node_modules"
+  ]
+}

--- a/recipes/react-trpc-fastify/tsconfig.json
+++ b/recipes/react-trpc-fastify/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@typewirets/typescript-config/base.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "baseUrl": "./src",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "isolatedModules": true,
+    "sourceMap": true,
+    "paths": {
+      "@typewirets/react-fastify/*": ["./*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/recipes/react-trpc-fastify/vite.config.mts
+++ b/recipes/react-trpc-fastify/vite.config.mts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
+// @ts-ignore
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  root: "src/",
+  plugins: [react(), tsconfigPaths(), tailwindcss()],
+  server: {
+    port: 3000,
+    proxy: {
+      "/trpc": {
+        target: "http://localhost:3001",
+      },
+    },
+  },
+  build: {
+    outDir: "../dist",
+    emptyOutDir: true,
+  },
+});

--- a/recipes/react-trpc-fastify/vitest.config.mts
+++ b/recipes/react-trpc-fastify/vitest.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      exclude: ["node_modules/", "src/**/*.test.ts"],
+    },
+  },
+});

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,6 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "test": {},


### PR DESCRIPTION
While working with React SPA example, A several problems were identified.

* ResolutionMonitor detects false postives, when resolution happens concurrently.
* In React example, we need resolution cache for a promise so that Suspense isn't stuck in an inifinite look when resolution fails.
* ResolutionError must be differentiated betweeen retriable error vs something or something that needs to just fail.
* Boilerplate codes for maintaing list of all wires were very cumbersome.
* Needing to have better best practices around wiring generic type to concrete implementation, as we planned to not support tagged resolution (such as using name, and etc)

This is great, because many of problems above were overlooked, or deemed unnecessarily to tackle, which was clearly wrong.

In response to above problems, followings were added.

* ResolutionMonitor is going to be created on each resolution request, thus we are free of concurrency concern.
* Top level TypeWireContainer will create ScopedResolutionContext in which will have its own requestId and newly created ResolutionMonitor. This ensures that a resolution request is tracked in its own request scope, while tapping into the parent's state of all bindings, creators, and loaded singleton instances if needed. (Hmm, we might have to comeback and cache the resolver promise to prevent duplciated creation of singleton instances.
* TypeWire now takes `imports` field with `createWith` method. This greatly helps ergonomics of keeping track of dependent wires and not needing to have full list of wires explicitly declared in everywhere. This would deserve yet another best practice example for keeping track of entire application specific wires though. We are currently doing it through TypeWireGroup, but I am starting to think it may not be necessarily, and we may have a better solution. I will follow up with that in subsequent PRs.

Additionally, I believe TypeWireError needs to be differenciated between Retryable vs not in subsequent PR, as well as the official react integration.