### PR TITLE
refactor(core): Improve dependency resolution with per-request tracking

### DIFF
--- a/packages/core/src/__tests__/container.test.ts
+++ b/packages/core/src/__tests__/container.test.ts
@@ -197,6 +197,7 @@ describe("TypeWireContainer", () => {
       expect(() => asyncServiceWire.getInstanceSync(container)).toThrow(
         expect.objectContaining({
           reason: "AsyncOnlyBinding",
+          retriable: true,
         }),
       );
     });


### PR DESCRIPTION
- Implement per-request isolation for dependency resolution
- Prevent false positives in circular dependency detection
- Add clearer error messages with highlighted error location
- Support concurrent resolution of the same dependency
- Improve JSDoc documentation for monitor and container classes

This change addresses the issue where concurrent resolution of the same dependency would incorrectly trigger circular dependency errors. Each resolution now gets its own isolated monitor instance, ensuring reliable parallel dependency resolution while maintaining accurate circular dependency detection.