### PR TITLE
[other] Include source files to NPM package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,14 @@
       "import": "./dist/esm/index.js"
     }
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "src/*.ts",
+    "!src/**/*.test.ts",
+    "!src/**/__tests__/**",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "pnpm clean && pnpm --filter '@typewirets/core' --parallel '/^build:.*/'",
     "build:cjs": "tsc --project tsconfig.build.json --outDir dist/cjs --module Commonjs --moduleResolution Node",

--- a/packages/inversify/package.json
+++ b/packages/inversify/package.json
@@ -13,7 +13,14 @@
       "require": "./dist/cjs/index.js"
     }
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "src/*.ts",
+    "!src/**/*.test.ts",
+    "!src/**/__tests__/**",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "pnpm clean && pnpm --filter '@typewirets/inversify' --parallel '/^build:.*/'",
     "build:cjs": "tsc --project tsconfig.build.json --outDir dist/cjs --module Commonjs --moduleResolution Node",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,16 @@
       "require": "./dist/cjs/index.js"
     }
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "src/*.ts",
+    "src/*.tsx",
+    "!src/**/*.test.ts",
+    "!src/**/*.test.tsx",
+    "!src/**/__tests__/**",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "pnpm clean && pnpm --filter '@typewirets/react' --parallel '/^build:.*/'",
     "build:cjs": "tsc --project tsconfig.build.json --outDir dist/cjs --module Commonjs --moduleResolution Node",


### PR DESCRIPTION
In order to get benefit from declarationMap and sourceMap, add non test source files into NPM package when publishing.

This would enhance developer experience.